### PR TITLE
PHP Warning - split() deprecated

### DIFF
--- a/HTML/QuickForm.php
+++ b/HTML/QuickForm.php
@@ -996,7 +996,7 @@ class HTML_QuickForm extends HTML_Common
     function updateElementAttr($elements, $attrs)
     {
         if (is_string($elements)) {
-            $elements = split('[ ]?,[ ]?', $elements);
+            $elements = preg_split('/[ ]?,[ ]?/', $elements);
         }
         foreach (array_keys($elements) as $key) {
             if (is_object($elements[$key]) && is_a($elements[$key], 'HTML_QuickForm_element')) {

--- a/HTML/QuickForm/select.php
+++ b/HTML/QuickForm/select.php
@@ -114,7 +114,7 @@ class HTML_QuickForm_select extends HTML_QuickForm_element {
     function setSelected($values)
     {
         if (is_string($values) && $this->getMultiple()) {
-            $values = split("[ ]?,[ ]?", $values);
+            $values = preg_split("/[ ]?,[ ]?/", $values);
         }
         if (is_array($values)) {
             $this->_values = array_values($values);


### PR DESCRIPTION
This fixes errors in CRM_HRReport_Form_Contact_HRDetailTest.
