### PR TITLE
CRM-10760 : improving the checking done for chinese specific values - by checking default civicrm language is chinese or not

### DIFF
--- a/jquery/plugins/jquery.autocomplete.js
+++ b/jquery/plugins/jquery.autocomplete.js
@@ -197,10 +197,10 @@ $.Autocompleter = function(input, options) {
 		$(input.form).unbind(".autocomplete");
 	}).bind("input", function() {
         // needed for chinese input? see CRM-6135 and http://plugins.jquery.com/node/14682 
-        // this breaks "delay" though, so lets only use it with chinese minChars setting 
-        if (options.minChars <= 1) { 
-            onChange(0, true); 
-        } 
+        // this breaks "delay" though, so lets only use it for chinese values
+        if (CRM.config.lcMessages === 'zh_CN' || CRM.config.lcMessages === 'zh_TW') {
+          onChange(0, true);
+        }       
   });
 	
 	function selectCurrent() {


### PR DESCRIPTION
The issue for 'delay' (property of autocomplete field) breaking is due to introduction of  <code>onChange(0, true);</code> which you can see at <code>line no. 202 packages/jquery/plugins/jquery.autocomplete.js </code> also a warning comment has been put above that code snippet about 'delay' break .

This code was introduced for CRM-6135 issue break fix (chinese character search not triggering) .
