### PR TITLE
-- fix for CRM-13435

### DIFF
--- a/dompdf/include/text_renderer.cls.php
+++ b/dompdf/include/text_renderer.cls.php
@@ -86,7 +86,12 @@ class Text_Renderer extends Abstract_Renderer {
       //$base = ($cpdf_font["UnderlinePosition"]*$size)/1000;
       //$descent = (($cpdf_font["Ascender"]-$cpdf_font["Descender"])*$size)/1000;
       
-      $fontBBox = $cpdf->fonts[$style->font_family]['FontBBox'];
+      if (array_key_exists($style->font_family, $cpdf->fonts)) {
+        $fontBBox = $cpdf->fonts[$style->font_family]['FontBBox'];
+      }
+      else {
+        $fontBBox = $cpdf->fonts[$cpdf->currentFont]['FontBBox'];
+      }
       $base = (($fontBBox[3]*$size)/1000) * 0.90;
       $descent = ($fontBBox[1]*$size)/1000;
       //print '<pre>Text_Renderer cpdf:'.$base.' '.$descent.' '.$size.'</pre>';


### PR DESCRIPTION
---
- CRM-13435: Notices when creating contribution thank-you letter
  http://issues.civicrm.org/jira/browse/CRM-13435

The notices are getting displayed because $style->font_family gets the value as "DejaVuSans" from print.css and this font is not available in the fonts folder of the package(README.DejaVuFonts.txt says that these fonts needs to be downloaded from dompdf site). So, $cpdf->fonts doesn't have the settings and contents of this font, thus producing the notice. So, I have made the fix by checking if $style->font_family value i.e. "..packages/dompdf/lib//fonts/dejavusans" exists in $cpdf->fonts. If not then use $cpdf->currentFont which would be times-roman. This also fixes the notice coming up in the reports after clicking on the "PDF" button.
