### PR TITLE
CRM-13860 - Strict warning: Non-static method Mail_RFC822::parseAddressList() should not be called statically

### DIFF
--- a/Mail.php
+++ b/Mail.php
@@ -254,7 +254,9 @@ class Mail
         // Parse recipients, leaving out all personal info. This is
         // for smtp recipients, etc. All relevant personal information
         // should already be in the headers.
-        $addresses = Mail_RFC822::parseAddressList($recipients, 'localhost', false);
+
+        $mail_object = new Mail_RFC822($recipients, 'localhost', false);
+        $addresses = $mail_object->parseAddressList();
 
         // If parseAddressList() returned a PEAR_Error object, just return it.
         if (is_a($addresses, 'PEAR_Error')) {


### PR DESCRIPTION
http://issues.civicrm.org/jira/browse/CRM-13860
