### PR TITLE
dompdf: fix handling of images when rendering multiple files in a row

### DIFF
--- a/dompdf/include/image_cache.cls.php
+++ b/dompdf/include/image_cache.cls.php
@@ -151,6 +151,8 @@ class Image_Cache {
       if (DEBUGPNG) print "[clear unlink $file]";
           unlink($file);
       }
+
+    self::$_cache = array();
     }
   
   static function detect_type($file) {


### PR DESCRIPTION
Fix picked from upstream Git (
https://github.com/dompdf/dompdf/commit/2c32bb3fbbdeafcd4628441de260361816aaefc7
) to properly clear the image cache, so
including images doesn't fail when rendering subsequent files with the
same images.

This issue might actually never occur in core CiviCRM itself, as it only
shows when generating multiple PDF files in one PHP invocation. However,
our extension does this, and thus becomes unusable with CiviCRM 4.4 --
so this is indeed a major regression, and the fix urgently needs to go
into the next bugfix release.

(The bug didn't manifest in previous CiviCRM releases, because of the
different setting of DOMPDF_ENABLE_REMOTE.)
