### PR TITLE
CRM-14126 - Wrap CURLOPT_FOLLOWLOCATION in a check for open_basedir and safe_mode

### DIFF
--- a/PayJunction/pjClasses.php
+++ b/PayJunction/pjClasses.php
@@ -193,8 +193,10 @@ class pjpgHttpsPost
       $ch = curl_init($url); 
       curl_setopt($ch, CURLOPT_HEADER, FALSE); 
       curl_setopt($ch, CURLOPT_POST, TRUE); 
-      curl_setopt($ch, CURLOPT_POSTFIELDS, $request); 
-      curl_setopt($ch, CURLOPT_FOLLOWLOCATION, 0);
+      curl_setopt($ch, CURLOPT_POSTFIELDS, $request);
+      if (ini_get('open_basedir') == '' && ini_get('safe_mode') == 'Off') {
+        curl_setopt($ch, CURLOPT_FOLLOWLOCATION, 0);
+      }
       curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE); 
       curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, TRUE);
       $content = curl_exec($ch); 


### PR DESCRIPTION
---
- CRM-14126: HttpClient.php library used by CiviCRM issues a PHP warning when open_basedir is set
  http://issues.civicrm.org/jira/browse/CRM-14126
