### PR TITLE
CRM-14814 CRM-8744 breaks on SMTP svrs requiring secure authentication

### DIFF
--- a/Net/SMTP.php
+++ b/Net/SMTP.php
@@ -601,8 +601,6 @@ class Net_SMTP
          * (SSL) socket connection. */
         if ($tls && version_compare(PHP_VERSION, '5.1.0', '>=') &&
             extension_loaded('openssl') && isset($this->_esmtp['STARTTLS']) &&
-            // CiviCRM: CRM-8744
-            ($this->_esmtp['STARTTLS'] == true) &&
             strncasecmp($this->host, 'ssl://', 6) !== 0) {
             /* Start the TLS connection attempt. */
             if (PEAR::isError($result = $this->_put('STARTTLS'))) {


### PR DESCRIPTION
See forum discussion http://forum.civicrm.org/index.php/topic,21960

The change made for CRM-8744 prevents CiviCRM connecting to a SMTP server unless that server provides authentication in the clear. This is insecure.

Notes:
1) The latest version of http://pear.php.net/package/Net_SMTP doesn't include this patch (released 2013-07-05) which tells me it's not an important patch
2) The source of the patch http://www.pear-forum.org/post-4935.html has gone off-air so we can't see why this patch was made or assess how well it was tested etc
3) I can demonstrate (in the Forum discussion) that this patch breaks the code
4) This patch creates a security issue, because it forces people to authenticate SMTP in the clear

---

 * [CRM-14814: CRM-8744 breaks on SMTP servers requiring secure TLS authentication](https://issues.civicrm.org/jira/browse/CRM-14814)
 * [CRM-8744: Upgrade and patch smtp library](https://issues.civicrm.org/jira/browse/CRM-8744)