### PR TITLE
PHPUnit: Fix assertTableRowCount()

### DIFF
--- a/PHPUnit/Extensions/Database/TestCase.php
+++ b/PHPUnit/Extensions/Database/TestCase.php
@@ -255,7 +255,7 @@ abstract class PHPUnit_Extensions_Database_TestCase extends PHPUnit_Framework_Te
      * @param int $expected Expected amount of rows in the table
      * @param string $message Optional message
      */
-    public static function assertTableRowCount($tableName, $expected, $message = '')
+    public function assertTableRowCount($tableName, $expected, $message = '')
     {
         $constraint = new PHPUnit_Extensions_Database_Constraint_TableRowCount($tableName, $expected);
         $actual = $this->getConnection()->getRowCount($tableName);


### PR DESCRIPTION
This method can't be static, as it accesses $this->getConnection().

This fix has been upstream for years (
https://github.com/sebastianbergmann/dbunit/commit/fce1b25ba4070eebf860653ec9f5b222c2a018ba
) -- but CiviCRM prefers sticking with an ancient buggy version of
PHPUnit/DBUnit...