### PR TITLE
CRM-16893 - Remove mysql_escape_string

### DIFF
--- a/DB/mysql.php
+++ b/DB/mysql.php
@@ -799,11 +799,7 @@ class DB_mysql extends DB_common
      */
     function escapeSimple($str)
     {
-        if (function_exists('mysql_real_escape_string')) {
-            return @mysql_real_escape_string($str, $this->connection);
-        } else {
-            return @mysql_escape_string($str);
-        }
+        return @mysql_real_escape_string($str, $this->connection);
     }
 
     // }}}


### PR DESCRIPTION
This function has been deprecated since 4.x, and I don't think it was used
at runtime (due to the conditional).

It seems weird to check for an edge-case where `mysql_escape_string` exists
but `mysql_real_escape_string` is missing.  Based on the PHP docs and some
Googling, this seems like it might have been an issue during the
months/years immediately after PHP 4.3.  Civi requires PHP 5.3+ now.

Civi has other parts of the code which rely on `mysql_real_escape_string`
and bomb if it's missing, so I think it's required anyway.