### PR TITLE
CRM-16881 -- Quote password in IMAP to accept spaces in them

### DIFF
--- a/ezc/Mail/src/transports/imap/imap_transport.php
+++ b/ezc/Mail/src/transports/imap/imap_transport.php
@@ -520,7 +520,7 @@ class ezcMailImapTransport
         }
 
         $tag = $this->getNextTag();
-        $this->connection->sendData( "{$tag} LOGIN {$user} {$password}" );
+        $this->connection->sendData( "{$tag} LOGIN {$user} \"{$password}\"" );
         $response = trim( $this->connection->getLine() );
         // hack for gmail, to fix issue #15837: imap.google.com (google gmail) changed IMAP response
         if ( $this->serverType === self::SERVER_GIMAP && strpos( $response, "* CAPABILITY" ) === 0 )


### PR DESCRIPTION
----------------------------------------
* CRM-16881: Spaces in password cause mail fetching to fail
  https://issues.civicrm.org/jira/browse/CRM-16881