### PR TITLE
CRM-17789 - PHP7 compat for DB_DataObject

### DIFF
--- a/DB/DataObject.php
+++ b/DB/DataObject.php
@@ -179,7 +179,7 @@ $GLOBALS['_DB_DATAOBJECT']['QUERYENDTIME'] = 0;
 // NOTE: Overload SEGFAULTS ON PHP4 + Zend Optimizer (see define before..)
 // these two are BC/FC handlers for call in PHP4/5
 
-if ( substr(phpversion(),0,1) == 5) {
+if ( substr(phpversion(),0,1) > 4) {
     class DB_DataObject_Overload
     {
         function __call($method,$args)


### PR DESCRIPTION
Resolves PHP7 syntax error, unexpected 'clone' in eval()'d code.

---

 * [CRM-17789: Support PHP 7](https://issues.civicrm.org/jira/browse/CRM-17789)