### PR TITLE
CRM-17789 free result fixes

### DIFF
--- a/DB.php
+++ b/DB.php
@@ -1394,12 +1394,9 @@ class DB_result
     function free()
     {
         $err = $this->dbh->freeResult($this->result);
-        if (DB::isError($err)) {
-            return $err;
-        }
         $this->result = false;
         $this->statement = false;
-        return true;
+        return $err;
     }
 
     // }}}

--- a/DB/DataObject.php
+++ b/DB/DataObject.php
@@ -4276,18 +4276,12 @@ class DB_DataObject extends DB_DataObject_Overload
     {
         global $_DB_DATAOBJECT;
 
-        if (isset($_DB_DATAOBJECT['RESULTS'][$this->_DB_resultid])) {
-            if ( is_resource( $_DB_DATAOBJECT['RESULTS'][$this->_DB_resultid]->result ) ) {
-                mysql_free_result( $_DB_DATAOBJECT['RESULTS'][$this->_DB_resultid]->result );
-            }
-            unset($_DB_DATAOBJECT['RESULTS'][$this->_DB_resultid]);
-        }
-
         if (isset($_DB_DATAOBJECT['RESULTFIELDS'][$this->_DB_resultid])) {
             unset($_DB_DATAOBJECT['RESULTFIELDS'][$this->_DB_resultid]);
         }
         if (isset($_DB_DATAOBJECT['RESULTS'][$this->_DB_resultid])) {
             unset($_DB_DATAOBJECT['RESULTS'][$this->_DB_resultid]);
+            $_DB_DATAOBJECT['RESULTS'][$this->_DB_resultid]->free();
         }
         // clear the staticGet cache as well.
         $this->_clear_cache();

--- a/DB/mysqli.php
+++ b/DB/mysqli.php
@@ -498,7 +498,11 @@ class DB_mysqli extends DB_common
      */
     function freeResult($result)
     {
-        return is_resource($result) ? mysqli_free_result($result) : false;
+        if (!$result instanceof mysqli_result) {
+            return false;
+        }
+        mysqli_free_result($result);
+        return true;
     }
 
     // }}}


### PR DESCRIPTION
These fixes make it possible to for CRM_Core_DAO->freeResult() to be mysql(i) extension independent, and also fixes the DB_mysqli->freeResult to actually clear it.

This is needed for supporting PHP7 without php_mysql extension, so it doesn't break (existing) installations.

---

 * [CRM-17789: Support PHP 7](https://issues.civicrm.org/jira/browse/CRM-17789)