### PR TITLE
CRM-18762 - Selenium update

### DIFF
--- a/SeleniumRC/selenium.sh
+++ b/SeleniumRC/selenium.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
 # Run selenium server with custom browser profile.
-echo; echo "Runnning selenium-server-2.35.0 "; echo;
-java -jar selenium-server/selenium-server-standalone-2.35.0.jar -firefoxProfileTemplate BrowserProfiles/firefox/
+echo; echo "Runnning selenium-server-2.53.0 "; echo;
+java -jar selenium-server/selenium-server-standalone-2.53.0.jar -firefoxProfileTemplate BrowserProfiles/firefox/


### PR DESCRIPTION
The version of Selenium in packages (2.35) no longer works with current versions of Firefox.  Updating to the current (2.53 version).

---

 * [CRM-18762: Upgrade Selenium package](https://issues.civicrm.org/jira/browse/CRM-18762)