### PR TITLE
CRM-19013 - Smarty - Do not truncate compiled templates

### DIFF
--- a/Smarty/Smarty.class.php
+++ b/Smarty/Smarty.class.php
@@ -1516,40 +1516,7 @@ class Smarty
                                                   $this->_compile_id );
         $compilePath .= '.php';
 
-        //for 'string:' resource smarty might going to fail to create
-        //compile file, so make sure we should have valid path, CRM-5890
-        $matches = array( );
-        if ( preg_match( '/^(\s+)?string:/', $resource_name, $matches ) ) {
-            if ( !$this->validateCompilePath( $compilePath ) ) {
-                $compilePath = $this->_get_auto_filename( $this->compile_dir,
-                                                          time().rand(),
-                                                          $this->_compile_id );
-                $compilePath .= '.php';
-            }
-        }
-
         return $compilePath;
-    }
-
-    /**
-     *  do check can smarty create a file w/ given path.
-     */
-    function validateCompilePath( $compilePath ) {
-        //first check for directory.
-        $dirname = dirname( $compilePath );
-        if ( !is_dir( $dirname ) ) {
-            require_once(SMARTY_CORE_DIR . 'core.create_dir_structure.php');
-            smarty_core_create_dir_structure( array('dir' => $dirname ), $this );
-        }
-
-        $isValid = false;
-        if ( $fd = @fopen( $compilePath, 'wb') ) {
-            $isValid = true;
-            @fclose( $fd );
-            @unlink($compilePath);
-        }
-
-        return $isValid;
     }
 
     /**
@@ -1786,13 +1753,11 @@ class Smarty
 
         if(isset($auto_source)) {
             // make source name safe for filename
-            $_filename = urlencode(basename($auto_source));
-            $_crc32 = sprintf('%08X', crc32($auto_source));
+            $_sha256 = hash('sha256', $auto_source);
             // prepend %% to avoid name conflicts with
             // with $params['auto_id'] names
-            $_crc32 = substr($_crc32, 0, 2) . $_compile_dir_sep .
-                      substr($_crc32, 0, 3) . $_compile_dir_sep . $_crc32;
-            $_return .= '%%' . $_crc32 . '%%' . $_filename;
+            $_return .= '%%' . substr($_sha256, 0, 2) . $_compile_dir_sep .
+                        substr($_sha256, 0, 3) . $_compile_dir_sep . $_sha256;
         }
 
         return $_return;


### PR DESCRIPTION
Truncating a compiled template leads to concurrency issues if another process is including the same file. See also CRM-11189 for a description of the "bus error" encountered when one of the concurrent processes dies.

---
- [CRM-19013: Compiled templates are truncated](https://issues.civicrm.org/jira/browse/CRM-19013)
- [CRM-11189: When CiviMail renders smarty templates for mailing, it saves them to disk](https://issues.civicrm.org/jira/browse/CRM-11189)
