### PR TITLE
CRM-19116: Rewrite smarty_core_get_include_path to improve performance (4.6)

### DIFF
--- a/Smarty/internals/core.get_include_path.php
+++ b/Smarty/internals/core.get_include_path.php
@@ -7,36 +7,21 @@
 
 /**
  * Get path to file from include_path
+ * CRM-19116: Rewrite to improve performance
+ * stream_resolve_include_path exists in PHP >= 5.3.2.
  *
- * @param string $file_path
- * @param string $new_file_path
+ * @param string[] $params
+ * @param object $smarty
+ *
  * @return boolean
- * @staticvar array|null
  */
+function smarty_core_get_include_path(&$params, &$smarty) {
 
-//  $file_path, &$new_file_path
-
-function smarty_core_get_include_path(&$params, &$smarty)
-{
-    static $_path_array = null;
-
-    if(!isset($_path_array)) {
-        $_ini_include_path = ini_get('include_path');
-
-        if(strstr($_ini_include_path,';')) {
-            // windows pathnames
-            $_path_array = explode(';',$_ini_include_path);
-        } else {
-            $_path_array = explode(':',$_ini_include_path);
-        }
-    }
-    foreach ($_path_array as $_include_path) {
-        if (@is_readable($_include_path . DIRECTORY_SEPARATOR . $params['file_path'])) {
-               $params['new_file_path'] = $_include_path . DIRECTORY_SEPARATOR . $params['file_path'];
-            return true;
-        }
-    }
-    return false;
+  $newpath = stream_resolve_include_path($params['file_path']);
+  if (@is_readable($newpath)) {
+    $params['new_file_path'] = $newpath;
+    return TRUE;
+  }
 }
 
 /* vim: set expandtab: */


### PR DESCRIPTION
See [CRM-19116: Smarty performance improvement](https://issues.civicrm.org/jira/browse/CRM-19116).
