### PR TITLE
CRM-17789 - Fix deprecate php4-style constructors for Log.php.

### DIFF
--- a/Log.php
+++ b/Log.php
@@ -101,6 +101,10 @@ class Log
                             '%{class}'      => '%8$s',
                             '%\{'           => '%%{');
 
+    public function __construct()
+    {
+    }
+
     /**
      * Utility function which wraps PHP's class_exists() function to ensure
      * consistent behavior between PHP versions 4 and 5.  Autoloading behavior


### PR DESCRIPTION
>Deprecated function: Methods with the same name as their class will not be constructors in a future version of PHP; Log has a deprecated constructor in require_once() (line 38 of /home/web/civi_master/civicrm/CRM/Core/Config.php).

Refer - https://github.com/pear/Log/blob/master/Log.php#L114

---

 * [CRM-17789: Support PHP 7](https://issues.civicrm.org/jira/browse/CRM-17789)