### PR TITLE
Disable peer verification for SMTP by default

### DIFF
--- a/Net/SMTP.php
+++ b/Net/SMTP.php
@@ -184,7 +184,7 @@ class Net_SMTP
         $this->pipelining = $pipelining;
 
         $this->_socket = new Net_Socket();
-        $this->_socket_options = $socket_options;
+        $this->_socket_options = array('ssl' => array('verify_peer_name' => false));
         $this->_timeout = $timeout;
 
         /* Include the Auth_SASL package.  If the package is available, we 


### PR DESCRIPTION
Problem came up when we were trying to test some new mailing services with CiviCRM 4.7, we kept getting "connection refused" errors and other similar messages with different protocols and ports entered in outbound mail settings.

The environment we have: Ubuntu 14.04, php 5.6, Drupal 7.3.x, CiviCRM 4.7.x.

The problem turns out to be related to php 5.6. Since php has enabled peer verification by default from 5.6.x, all the SMTP connection via SSL and TLS will fail in CiviCRM.

There is a temporary fix for this. Change in packages/Net/SMTP.php

line $this->_socket_options = $socket_options;

to $this->_socket_options = array('ssl' => array('verify_peer_name' => false));

The above solves the problem with SMTP failure however we should either be updating CiviCRM or turn off the peer verification elsewhere in php setting. Otherwise, the document here probably should updated to point out 5.6 compatibility issue.

My answer for ref: http://civicrm.stackexchange.com/questions/10964/smtp-connection-failing-problem/10966#10966
