### PR TITLE
CRM-19564 - Add "prefix" and "suffix" properties to QuickForm elements

### DIFF
--- a/HTML/QuickForm/Renderer/Array.php
+++ b/HTML/QuickForm/Renderer/Array.php
@@ -260,7 +260,7 @@ class HTML_QuickForm_Renderer_Array extends HTML_QuickForm_Renderer
     * Creates an array representing an element
     *
     * @access private
-    * @param  HTML_QuickForm_element    element being processed
+    * @param  HTML_QuickForm_element    $element being processed
     * @param  bool                      Whether an element is required
     * @param  string                    Error associated with the element
     * @return array
@@ -273,6 +273,8 @@ class HTML_QuickForm_Renderer_Array extends HTML_QuickForm_Renderer
             'type'      => $element->getType(),
             'frozen'    => $element->isFrozen(),
             'required'  => $required,
+            'prefix'    => $element->getPrefix(),
+            'suffix'    => $element->getsuffix(),
             'error'     => $error
         );
 

--- a/HTML/QuickForm/element.php
+++ b/HTML/QuickForm/element.php
@@ -75,7 +75,16 @@ class HTML_QuickForm_element extends HTML_Common
      * @access    private
      */
     var $_persistantFreeze = false;
-    
+
+    /**
+     * @var string
+     */
+    var $_suffix = '';
+    /**
+     * @var string
+     */
+    var $_prefix = '';
+
     // }}}
     // {{{ constructor
     
@@ -192,6 +201,38 @@ class HTML_QuickForm_element extends HTML_Common
         // interface
         return null;
     } // end func getValue
+
+    /**
+     * @return string
+     */
+    function getSuffix()
+    {
+        return $this->_suffix;
+    }
+
+    /**
+     * @return string
+     */
+    function getPrefix()
+    {
+        return $this->_prefix;
+    }
+
+    /**
+     * @param string $markup
+     */
+    function setSuffix($markup)
+    {
+        $this->_suffix = $markup;
+    }
+
+    /**
+     * @param string $markup
+     */
+    function setPrefix($markup)
+    {
+        $this->_prefix = $markup;
+    }
     
     // }}}
     // {{{ freeze()

--- a/HTML/QuickForm/group.php
+++ b/HTML/QuickForm/group.php
@@ -304,7 +304,7 @@ class HTML_QuickForm_group extends HTML_QuickForm_element
         $renderer = new HTML_QuickForm_Renderer_Default();
         $renderer->setElementTemplate('{element}');
         $this->accept($renderer);
-        return $renderer->toHtml();
+        return $this->getPrefix() . $renderer->toHtml() . $this->getSuffix();
     } //end func toHtml
 
     // }}}

--- a/HTML/QuickForm/input.php
+++ b/HTML/QuickForm/input.php
@@ -149,9 +149,9 @@ class HTML_QuickForm_input extends HTML_QuickForm_element
     function toHtml()
     {
         if ($this->_flagFrozen) {
-            return $this->getFrozenHtml();
+            return $this->getPrefix() . $this->getFrozenHtml() . $this->getSuffix();
         } else {
-            return $this->_getTabs() . '<input' . $this->_getAttrString($this->_attributes) . ' />';
+            return $this->_getTabs() . $this->getPrefix() . '<input' . $this->_getAttrString($this->_attributes) . ' />' . $this->getSuffix();
         }
     } //end func toHtml
 


### PR DESCRIPTION
- [CRM-19564: Custom field "Options per line" breaks the "Clear" button](https://issues.civicrm.org/jira/browse/CRM-19564)
