### PR TITLE
CRM-17789 Add in insertId function

### DIFF
--- a/DB/DataObject.php
+++ b/DB/DataObject.php
@@ -4293,6 +4293,10 @@ class DB_DataObject extends DB_DataObject_Overload
 
 
 
+  public function lastInsertId() {
+    $DB = &$_DB_DATAOBJECT['CONNECTIONS'][$this->_database_dsn_md5];
+    return $DB->lastInsertId();
+  }
 
 }
 // technially 4.3.2RC1 was broken!!

--- a/DB/common.php
+++ b/DB/common.php
@@ -2246,6 +2246,9 @@ class DB_common extends PEAR
         }
     }
 
+    function lastInsertId() {
+        throw new \RuntimeException("Not implemented: " . get_class($this) . '::lastInsertId');
+    }
     // }}}
 }
 

--- a/DB/mysql.php
+++ b/DB/mysql.php
@@ -1030,6 +1030,10 @@ class DB_mysql extends DB_common
 
     // }}}
 
+    function lastInsertId() {
+        return mysql_insert_id($this->connection);
+    }
+
 }
 
 /*

--- a/DB/mysqli.php
+++ b/DB/mysqli.php
@@ -1081,6 +1081,10 @@ class DB_mysqli extends DB_common
 
     // }}}
 
+    function lastInsertId() {
+        return mysqli_insert_id($this->connection);
+    }
+
 }
 
 /*


### PR DESCRIPTION
@jackrabbithanna 

Hey Mark this is a small thing that would allow testing to happen to potentially allow 4.6 to support php7 if needed, I have other PRs open to do the php7 changes that are needed but can't properly test without this function

---

 * [CRM-17789: Support PHP 7](https://issues.civicrm.org/jira/browse/CRM-17789)