### PR TITLE
CRM-20178 & CRM-20414 apply db level fixes to update (only applied to insert)

### DIFF
--- a/DB/DataObject.php
+++ b/DB/DataObject.php
@@ -968,11 +968,6 @@ class DB_DataObject extends DB_DataObject_Overload
             if (!isset($this->$k)) {
                 continue;
             }
-            // dont insert data into mysql timestamps
-            // use query() if you really want to do this!!!!
-            if ($v & DB_DATAOBJECT_MYSQLTIMESTAMP) {
-                continue;
-            }
 
             if ($leftq) {
                 $leftq  .= ', ';

--- a/DB/DataObject.php
+++ b/DB/DataObject.php
@@ -994,6 +994,19 @@ class DB_DataObject extends DB_DataObject_Overload
                 $rightq .= " NULL ";
                 continue;
             }
+          if (($v & DB_DATAOBJECT_DATE) || ($v & DB_DATAOBJECT_TIME) || $v & DB_DATAOBJECT_MYSQLTIMESTAMP) {
+            if (strpos($this->$k, '-') !== FALSE) {
+              /*
+               * per CRM-14986 we have been having ongoing problems with the format returned from $dao->find(TRUE) NOT
+               * being acceptable for an immediate save. This has resulted in the codebase being smattered with
+               * instances of CRM_Utils_Date::isoToMysql for date fields retrieved in this way
+               * which seems both risky (have to remember to do it for every field) & cludgey.
+               * doing it here should be safe as only fields with a '-' in them will be affected - if they are
+               *  already formatted or empty then this line will not be hit
+               */
+              $this->$k = CRM_Utils_Date::isoToMysql($this->$k);
+            }
+          }
             // DATE is empty... on a col. that can be null..
             // note: this may be usefull for time as well..
             if (!$this->$k &&


### PR DESCRIPTION
* [CRM-20178: Writes to timestamp fields are silently ignored by $dao-\>save\(\)](https://issues.civicrm.org/jira/browse/CRM-20178)
 * [CRM-20414: Writes to date & timestamp fail on insert but not update - this is a follow on from CRM-14986](https://issues.civicrm.org/jira/browse/CRM-20414)

---

 * [CRM-14986: fatal error when trying to cancel a contribution recur payment](https://issues.civicrm.org/jira/browse/CRM-14986)