### PR TITLE
CRM-20445 Add dispatcher to modifyQuery

### DIFF
--- a/DB.php
+++ b/DB.php
@@ -641,7 +641,9 @@ class DB
                 . 'ALTER|GRANT|REVOKE|'
                 . 'SAVEPOINT|ROLLBACK|'
                 . 'LOCK|UNLOCK';
-        if (preg_match('/^\s*"?(' . $manips . ')\s+/i', $query)) {
+        // First strip any leading comments.
+        $queryString = (substr($query, 0, 2) === '/*') ? substr($query, strpos($query, '*/') + 2) : $query;
+        if (preg_match('/^\s*"?(' . $manips . ')\s+/i', $queryString)) {
             return true;
         }
         return false;

--- a/DB/DataObject.php
+++ b/DB/DataObject.php
@@ -2462,8 +2462,9 @@ class DB_DataObject extends DB_DataObject_Overload
             }
             return $this->raiseError($result);
         }
-
-        $action = strtolower(substr(trim($string),0,6));
+        // Strip any prepended comments
+        $queryString = (substr($string, 0, 2) === '/*') ? substr($string, strpos($string, '*/') + 2) : $string;
+        $action = strtolower(substr(trim($queryString),0,6));
 
         if (!empty($_DB_DATAOBJECT['CONFIG']['debug']) || defined('CIVICRM_DEBUG_LOG_QUERY')) {
           $timeTaken = sprintf("%0.6f", microtime(TRUE) - $time);

--- a/DB/common.php
+++ b/DB/common.php
@@ -1148,7 +1148,14 @@ class DB_common extends PEAR
      */
     function modifyQuery($query)
     {
-        return $query;
+
+      if (class_exists('Civi\Core\Container') && \Civi\Core\Container::isContainerBooted()) {
+        Civi\Core\Container::singleton()->get('dispatcher')->dispatch('civi.db.query',
+          \Civi\Core\Event\GenericHookEvent::create(array('query' => &$query))
+        );
+      }
+      return $query;
+
     }
 
     // }}}


### PR DESCRIPTION
* [CRM-20445: Add query dispatcher to allow query modification](https://issues.civicrm.org/jira/browse/CRM-20445)

This allows a query to be modified from an extension - e.g by prepending data like '/* Query run by user 45*/'

@totten this is working for me now....