### PR TITLE
(WIP) CRM-18408, update for TLS issues seen in PHP5.6

### DIFF
--- a/Net/SMTP.php
+++ b/Net/SMTP.php
@@ -183,6 +183,14 @@ class Net_SMTP
         }
         $this->pipelining = $pipelining;
 
+        if (!isset($socket_options['ssl'])) {
+            if (!is_array($socket_options)) $socket_options = array();
+            $caConfig = CA_Config_Stream::singleton();
+            if ($caConfig->isEnableSSL()) {
+                $socket_options['ssl'] = $caConfig->toStreamOptions();
+            }
+        }
+
         $this->_socket = new Net_Socket();
         $this->_socket_options = $socket_options;
         $this->_timeout = $timeout;
@@ -579,29 +587,29 @@ class Net_SMTP
     /**
      * Attempt to do SMTP authentication.
      *
-     * @param string The userid to authenticate as.
-     * @param string The password to authenticate with.
-     * @param string The requested authentication method.  If none is
-     *               specified, the best supported method will be used.
-     * @param bool   Flag indicating whether or not TLS should be attempted.
-     * @param string An optional authorization identifier.  If specified, this
-     *               identifier will be used as the authorization proxy.
+     * @param string $uid    The userid to authenticate as.
+     * @param string $pwd    The password to authenticate with.
+     * @param string $method The requested authentication method.  If none is
+     *                       specified, the best supported method will be used.
+     * @param bool   $tls    Flag indicating whether or not TLS should be attempted.
+     * @param string $authz  An optional authorization identifier.  If specified, this
+     *                       identifier will be used as the authorization proxy.
      *
      * @return mixed Returns a PEAR_Error with an error message on any
      *               kind of failure, or true on success.
-     * @access public
-     * @since  1.0
+     * @since 1.0
      */
-    function auth($uid, $pwd , $method = '', $tls = true, $authz = '')
+    public function auth($uid, $pwd , $method = '', $tls = true, $authz = '')
     {
         /* We can only attempt a TLS connection if one has been requested,
-         * we're running PHP 5.1.0 or later, have access to the OpenSSL 
-         * extension, are connected to an SMTP server which supports the 
-         * STARTTLS extension, and aren't already connected over a secure 
+         * we're running PHP 5.1.0 or later, have access to the OpenSSL
+         * extension, are connected to an SMTP server which supports the
+         * STARTTLS extension, and aren't already connected over a secure
          * (SSL) socket connection. */
-        if ($tls && version_compare(PHP_VERSION, '5.1.0', '>=') &&
-            extension_loaded('openssl') && isset($this->_esmtp['STARTTLS']) &&
-            strncasecmp($this->host, 'ssl://', 6) !== 0) {
+        if ($tls && version_compare(PHP_VERSION, '5.1.0', '>=')
+            && extension_loaded('openssl') && isset($this->esmtp['STARTTLS'])
+            && strncasecmp($this->host, 'ssl://', 6) !== 0
+        ) {
             /* Start the TLS connection attempt. */
             if (PEAR::isError($result = $this->_put('STARTTLS'))) {
                 return $result;
@@ -609,7 +617,18 @@ class Net_SMTP
             if (PEAR::isError($result = $this->_parseResponse(220))) {
                 return $result;
             }
-            if (PEAR::isError($result = $this->_socket->enableCrypto(true, STREAM_CRYPTO_METHOD_TLS_CLIENT))) {
+
+            if (isset($this->socket_options['ssl']['crypto_method'])) {
+                $crypto_method = $this->socket_options['ssl']['crypto_method'];
+            } else {
+                /* STREAM_CRYPTO_METHOD_TLS_ANY_CLIENT constant does not exist
+                 * and STREAM_CRYPTO_METHOD_SSLv23_CLIENT constant is
+                 * inconsistent across PHP versions. */
+                $crypto_method = STREAM_CRYPTO_METHOD_TLS_CLIENT
+                    | @STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT
+                    | @STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT;
+            }
+            if (PEAR::isError($result = $this->socket->enableCrypto(true, $crypto_method))) {
                 return $result;
             } elseif ($result !== true) {
                 return PEAR::raiseError('STARTTLS failed');
@@ -650,9 +669,9 @@ class Net_SMTP
             list($object, $method) = $this->auth_methods[$method];
             $result = $object->{$method}($uid, $pwd, $authz, $this);
         } else {
-            $func =  $this->auth_methods[$method];
+            $func   = $this->auth_methods[$method];
             $result = $func($uid, $pwd, $authz, $this);
-         }
+        }
 
         /* If an error was encountered, return the PEAR_Error object. */
         if (PEAR::isError($result)) {

--- a/Net/Socket.php
+++ b/Net/Socket.php
@@ -583,6 +583,7 @@ class Net_Socket extends PEAR {
             if (!is_resource($this->fp)) {
                 return $this->raiseError('not connected');
             }
+            // CRM-18408 TLS warnings are hidden by @ below.
             return @stream_socket_enable_crypto($this->fp, $enabled, $type);
         } else {
             return $this->raiseError('Net_Socket::enableCrypto() requires php version >= 5.1.0');


### PR DESCRIPTION
PHP5.6 introduces peer validation by default - this is a good thing.

But it makes some TLS negotiation issues visible too. This ports changes from Net_SMTP-1.7.1 to our ancient patched 2011 version.

We could also update Net_SMTP properly, but our version is modified so that wants review.

This works for the specific site I was able to test (Elasticemail).

This commit accidentally includes 1f656ec which should remain but be separately committed.

---

 * [CRM-18408: SMTP connection via SSL and TLS in PHP 5.6](https://issues.civicrm.org/jira/browse/CRM-18408)