### PR TITLE
Update for PHP5.6.x changes with regard to TLS.

### DIFF
--- a/Net/Socket.php
+++ b/Net/Socket.php
@@ -583,6 +583,7 @@ class Net_Socket extends PEAR {
             if (!is_resource($this->fp)) {
                 return $this->raiseError('not connected');
             }
+            // CRM-18408 TLS warnings are hidden by @ below.
             return @stream_socket_enable_crypto($this->fp, $enabled, $type);
         } else {
             return $this->raiseError('Net_Socket::enableCrypto() requires php version >= 5.1.0');


### PR DESCRIPTION
In PHP5.6.7 there are changes to the constants relating to TLS stream socket options.

This basically pear/Net_SMTP@90de8451.

CRM-18408

---

 * [CRM-18408: SMTP connection via SSL and TLS in PHP 5.6](https://issues.civicrm.org/jira/browse/CRM-18408)