### PR TITLE
CRM-17652: Make civicrm-packages into a composer library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,5 @@
+{
+  "name": "civicrm/civicrm-packages",
+  "description": "Legacy third party dependencies for CiviCRM",
+  "type": "library"
+}


### PR DESCRIPTION
This one needs to be merged before https://github.com/civicrm/civicrm-core/pull/10694 can use composer to pull in civicrm-packages and have it actually work (ie. pass tests)

* [CRM-17652: Symfony conflict between Civi and Drupal 8](https://issues.civicrm.org/jira/browse/CRM-17652)