### PR TITLE
CRM-21458: Replace addcslashes call with json_encode creating options

### DIFF
--- a/HTML/QuickForm/hierselect.php
+++ b/HTML/QuickForm/hierselect.php
@@ -362,7 +362,7 @@ class HTML_QuickForm_hierselect extends HTML_QuickForm_group
             if ($js != '') {
                 $js .= ",\n";
             }
-            $js .= '"'.$optValue.'":"'.json_encode($options).'"';
+            $js .= '"'.$optValue.'":'.json_encode($options);
         }
     }
 

--- a/HTML/QuickForm/hierselect.php
+++ b/HTML/QuickForm/hierselect.php
@@ -362,7 +362,7 @@ class HTML_QuickForm_hierselect extends HTML_QuickForm_group
             if ($js != '') {
                 $js .= ",\n";
             }
-            $js .= '"'.$optValue.'":"'.addcslashes($options,'"').'"';
+            $js .= '"'.$optValue.'":"'.json_encode($options).'"';
         }
     }
 


### PR DESCRIPTION
json_encode should ensure that *all* escapes required for JS string values
are present.

----------------------------------------
* CRM-21458: (CIVICRM-742) HTML_QuickForm_hierselect doesn't handle JS escaping properly
  https://issues.civicrm.org/jira/browse/CRM-21458