### PR TITLE
(accessibility/misc-core-fixes/issues/3) Add aria-label attribute to Quickform elements

### DIFF
--- a/HTML/QuickForm/element.php
+++ b/HTML/QuickForm/element.php
@@ -3,7 +3,7 @@
 
 /**
  * Base class for form elements
- * 
+ *
  * PHP versions 4 and 5
  *
  * LICENSE: This source file is subject to version 3.01 of the PHP license
@@ -30,7 +30,7 @@ require_once 'HTML/Common.php';
 
 /**
  * Base class for form elements
- * 
+ *
  * @category    HTML
  * @package     HTML_QuickForm
  * @author      Adam Daniel <adaniel1@eesus.jnj.com>
@@ -75,13 +75,13 @@ class HTML_QuickForm_element extends HTML_Common
      * @access    private
      */
     var $_persistantFreeze = false;
-    
+
     // }}}
     // {{{ constructor
-    
+
     /**
      * Class constructor
-     * 
+     *
      * @param    string     Name of the element
      * @param    mixed      Label(s) for the element
      * @param    mixed      Associative array of tag attributes or HTML attributes name="value" pairs
@@ -99,7 +99,7 @@ class HTML_QuickForm_element extends HTML_Common
             $this->setLabel($elementLabel);
         }
     } //end constructor
-    
+
     // }}}
     // {{{ apiVersion()
 
@@ -135,7 +135,7 @@ class HTML_QuickForm_element extends HTML_Common
 
     /**
      * Sets the input field name
-     * 
+     *
      * @param     string    $name   Input field name attribute
      * @since     1.0
      * @access    public
@@ -145,13 +145,13 @@ class HTML_QuickForm_element extends HTML_Common
     {
         // interface method
     } //end func setName
-    
+
     // }}}
     // {{{ getName()
 
     /**
      * Returns the element name
-     * 
+     *
      * @since     1.0
      * @access    public
      * @return    string
@@ -160,7 +160,7 @@ class HTML_QuickForm_element extends HTML_Common
     {
         // interface method
     } //end func getName
-    
+
     // }}}
     // {{{ setValue()
 
@@ -192,13 +192,13 @@ class HTML_QuickForm_element extends HTML_Common
         // interface
         return null;
     } // end func getValue
-    
+
     // }}}
     // {{{ freeze()
 
     /**
      * Freeze the element so that only its value is returned
-     * 
+     *
      * @access    public
      * @return    void
      */
@@ -227,7 +227,7 @@ class HTML_QuickForm_element extends HTML_Common
 
     /**
      * Returns the value of field without HTML tags
-     * 
+     *
      * @since     1.0
      * @access    public
      * @return    string
@@ -238,13 +238,13 @@ class HTML_QuickForm_element extends HTML_Common
         return (strlen($value)? htmlspecialchars($value): '&nbsp;') .
                $this->_getPersistantData();
     } //end func getFrozenHtml
-    
+
     // }}}
     // {{{ _getPersistantData()
 
    /**
     * Used by getFrozenHtml() to pass the element's value if _persistantFreeze is on
-    * 
+    *
     * @access private
     * @return string
     */
@@ -283,7 +283,7 @@ class HTML_QuickForm_element extends HTML_Common
     /**
      * Sets wether an element value should be kept in an hidden field
      * when the element is frozen or not
-     * 
+     *
      * @param     bool    $persistant   True if persistant value
      * @since     2.0
      * @access    public
@@ -299,7 +299,7 @@ class HTML_QuickForm_element extends HTML_Common
 
     /**
      * Sets display text for the element
-     * 
+     *
      * @param     string    $label  Display text for the element
      * @since     1.3
      * @access    public
@@ -308,6 +308,11 @@ class HTML_QuickForm_element extends HTML_Common
     function setLabel($label)
     {
         $this->_label = $label;
+        // if aria-label attribute is not set and label is present, then set this missing property
+        //  with label value, that will provide accessible label to respective input element
+        if (!$this->getAttribute('aria-label') && $label) {
+          $this->updateAttributes(array('aria-label' => $label));
+        }
     } //end func setLabel
 
     // }}}
@@ -315,7 +320,7 @@ class HTML_QuickForm_element extends HTML_Common
 
     /**
      * Returns display text for the element
-     * 
+     *
      * @since     1.3
      * @access    public
      * @return    string
@@ -330,7 +335,7 @@ class HTML_QuickForm_element extends HTML_Common
 
     /**
      * Tries to find the element value from the values array
-     * 
+     *
      * @since     2.7
      * @access    private
      * @return    mixed
@@ -345,7 +350,7 @@ class HTML_QuickForm_element extends HTML_Common
             return $values[$elementName];
         } elseif (strpos($elementName, '[')) {
             $myVar = "['" . str_replace(
-                         array('\\', '\'', ']', '['), array('\\\\', '\\\'', '', "']['"), 
+                         array('\\', '\'', ']', '['), array('\\\\', '\\\'', '', "']['"),
                          $elementName
                      ) . "']";
             return eval("return (isset(\$values$myVar)) ? \$values$myVar : null;");
@@ -407,7 +412,7 @@ class HTML_QuickForm_element extends HTML_Common
     * @param bool                       Whether an element is required
     * @param string                     An error message associated with an element
     * @access public
-    * @return void 
+    * @return void
     */
     function accept(&$renderer, $required=false, $error=null)
     {
@@ -419,12 +424,12 @@ class HTML_QuickForm_element extends HTML_Common
 
    /**
     * Automatically generates and assigns an 'id' attribute for the element.
-    * 
+    *
     * Currently used to ensure that labels work on radio buttons and
     * checkboxes. Per idea of Alexander Radivanovich.
     *
     * @access private
-    * @return void 
+    * @return void
     */
     function _generateId()
     {
@@ -454,7 +459,7 @@ class HTML_QuickForm_element extends HTML_Common
         }
         return $this->_prepareValue($value, $assoc);
     }
-    
+
     // }}}
     // {{{ _prepareValue()
 
@@ -479,7 +484,7 @@ class HTML_QuickForm_element extends HTML_Common
             } else {
                 $valueAry = array();
                 $myIndex  = "['" . str_replace(
-                                array('\\', '\'', ']', '['), array('\\\\', '\\\'', '', "']['"), 
+                                array('\\', '\'', ']', '['), array('\\\\', '\\\'', '', "']['"),
                                 $name
                             ) . "']";
                 eval("\$valueAry$myIndex = \$value;");
@@ -487,7 +492,7 @@ class HTML_QuickForm_element extends HTML_Common
             }
         }
     }
-    
+
     // }}}
 } // end class HTML_QuickForm_element
 ?>


### PR DESCRIPTION
Overview
----------------------------------------
This PR is about adding accessible labels by adding ```aria-label``` attribute to all kind of input fields.
Ticket: https://lab.civicrm.org/accessibility/misc-core-fixes/issues/3

Before
----------------------------------------
Public form - online contribution page
![screen shot 2018-04-05 at 12 43 48 pm](https://user-images.githubusercontent.com/3735621/38351887-0bcb0352-38cf-11e8-8bf1-dd9dc544f0b7.png)


After
----------------------------------------
Public form - online contribution page
![screen shot 2018-04-05 at 12 42 38 pm](https://user-images.githubusercontent.com/3735621/38351976-64a762cc-38cf-11e8-9217-83f26ba44a69.png)


