### PR TITLE
Strip trailing whitespace in quickform package

### DIFF
--- a/HTML/Common.php
+++ b/HTML/Common.php
@@ -11,7 +11,7 @@
  * http://www.php.net/license/3_01.txt If you did not receive a copy of
  * the PHP License and are unable to obtain it through the web, please
  * send a note to license@php.net so we can mail you a copy immediately.
- * 
+ *
  * @category    HTML
  * @package     HTML_Common
  * @author      Adam Daniel <adaniel1@eesus.jnj.com>
@@ -19,7 +19,7 @@
  * @license     http://www.php.net/license/3_01.txt PHP License 3.01
  * @version     CVS: $Id: Common.php,v 1.15 2009/04/03 15:26:22 avb Exp $
  * @link        http://pear.php.net/package/HTML_Common/
- */ 
+ */
 
 /**
  * Base class for all HTML classes
@@ -445,8 +445,8 @@ class HTML_Common
      * $charset = HTML_Common::charset();
      * </code>
      *
-     * @param   string  New charset to use. Omit if just getting the 
-     *                  current value. Consult the htmlspecialchars() docs 
+     * @param   string  New charset to use. Omit if just getting the
+     *                  current value. Consult the htmlspecialchars() docs
      *                  for a list of supported character sets.
      * @return  string  Current charset
      * @access  public

--- a/HTML/QuickForm.php
+++ b/HTML/QuickForm.php
@@ -3,7 +3,7 @@
 
 /**
  * Create, validate and process HTML forms
- * 
+ *
  * PHP versions 4 and 5
  *
  * LICENSE: This source file is subject to version 3.01 of the PHP license
@@ -37,8 +37,8 @@ require_once 'HTML/Common.php';
  * @see HTML_QuickForm::registerElementType(), HTML_QuickForm::getRegisteredTypes(),
  *      HTML_QuickForm::isTypeRegistered()
  * @global array $GLOBALS['HTML_QUICKFORM_ELEMENT_TYPES']
- */ 
-$GLOBALS['HTML_QUICKFORM_ELEMENT_TYPES'] = 
+ */
+$GLOBALS['HTML_QUICKFORM_ELEMENT_TYPES'] =
         array(
             'group'         =>array('HTML/QuickForm/group.php','HTML_QuickForm_group'),
             'hidden'        =>array('HTML/QuickForm/hidden.php','HTML_QuickForm_hidden'),
@@ -67,7 +67,7 @@ $GLOBALS['HTML_QUICKFORM_ELEMENT_TYPES'] =
         );
 
 /**
- * Validation rules known to HTML_QuickForm 
+ * Validation rules known to HTML_QuickForm
  * @see HTML_QuickForm::registerRule(), HTML_QuickForm::getRegisteredRules(),
  *      HTML_QuickForm::isRuleRegistered()
  * @global array $GLOBALS['_HTML_QuickForm_registered_rules']
@@ -93,11 +93,11 @@ $GLOBALS['_HTML_QuickForm_registered_rules'] = array(
 /**#@+
  * Error codes for HTML_QuickForm
  *
- * Codes are mapped to textual messages by errorMessage() method, if you add a 
+ * Codes are mapped to textual messages by errorMessage() method, if you add a
  * new code be sure to add a new message for it to errorMessage()
  *
  * @see HTML_QuickForm::errorMessage()
- */ 
+ */
 define('QUICKFORM_OK',                      1);
 define('QUICKFORM_ERROR',                  -1);
 define('QUICKFORM_INVALID_RULE',           -2);
@@ -155,7 +155,7 @@ class HTML_QuickForm extends HTML_Common
      * @since     1.0
      * @var  array
      * @access   private
-     */ 
+     */
     var $_required = array();
 
     /**
@@ -163,7 +163,7 @@ class HTML_QuickForm extends HTML_Common
      * @since     1.0
      * @var  string
      * @access   public
-     */ 
+     */
     var $_jsPrefix = 'Invalid information entered.';
 
     /**
@@ -171,7 +171,7 @@ class HTML_QuickForm extends HTML_Common
      * @since     1.0
      * @var  string
      * @access   public
-     */ 
+     */
     var $_jsPostfix = 'Please correct these fields.';
 
     /**
@@ -328,7 +328,7 @@ class HTML_QuickForm extends HTML_Common
                 default:
                     $this->_maxFileSize = $matches['1'];
             }
-        }    
+        }
     } // end constructor
 
     // }}}
@@ -478,8 +478,8 @@ class HTML_QuickForm extends HTML_Common
      * Initializes constant form values.
      * These values won't get overridden by POST or GET vars
      *
-     * @param     array   $constantValues        values used to fill the form    
-     * @param     mixed    $filter              (optional) filter(s) to apply to all default values    
+     * @param     array   $constantValues        values used to fill the form
+     * @param     mixed    $filter              (optional) filter(s) to apply to all default values
      *
      * @since     2.0
      * @access    public
@@ -555,8 +555,8 @@ class HTML_QuickForm extends HTML_Common
 
     /**
      * Creates a new form element of the given type.
-     * 
-     * This method accepts variable number of parameters, their 
+     *
+     * This method accepts variable number of parameters, their
      * meaning and count depending on $elementType
      *
      * @param     string     $elementType    type of element to add (text, textarea, file...)
@@ -614,9 +614,9 @@ class HTML_QuickForm extends HTML_Common
 
     /**
      * Adds an element into the form
-     * 
-     * If $element is a string representing element type, then this 
-     * method accepts variable number of parameters, their meaning 
+     *
+     * If $element is a string representing element type, then this
+     * method accepts variable number of parameters, their meaning
      * and count depending on $element
      *
      * @param    mixed      $element        element object or type of element to add (text, textarea, file...)
@@ -668,7 +668,7 @@ class HTML_QuickForm extends HTML_Common
 
         return $elementObject;
     } // end func addElement
-    
+
     // }}}
     // {{{ insertElementBefore()
 
@@ -766,7 +766,7 @@ class HTML_QuickForm extends HTML_Common
         $group =& $this->addElement('group', $name, $groupLabel, $elements, $separator, $appendName);
         return $group;
     } // end func addGroup
-    
+
     // }}}
     // {{{ &getElement()
 
@@ -794,8 +794,8 @@ class HTML_QuickForm extends HTML_Common
 
     /**
      * Returns the element's raw value
-     * 
-     * This returns the value as submitted by the form (not filtered) 
+     *
+     * This returns the value as submitted by the form (not filtered)
      * or set via setDefaults() or setConstants()
      *
      * @param     string     $element    Element name
@@ -835,7 +835,7 @@ class HTML_QuickForm extends HTML_Common
      * @since     2.0
      * @access    public
      * @return    mixed     submitted element value or null if not set
-     */    
+     */
     function getSubmitValue($elementName)
     {
         $value = null;
@@ -852,11 +852,11 @@ class HTML_QuickForm extends HTML_Common
 
         } elseif (false !== ($pos = strpos($elementName, '['))) {
             $base = str_replace(
-                        array('\\', '\''), array('\\\\', '\\\''), 
+                        array('\\', '\''), array('\\\\', '\\\''),
                         substr($elementName, 0, $pos)
                     );
             $idx  = "['" . str_replace(
-                        array('\\', '\'', ']', '['), array('\\\\', '\\\'', '', "']['"), 
+                        array('\\', '\'', ']', '['), array('\\\\', '\\\'', '', "']['"),
                         substr($elementName, $pos + 1, -1)
                     ) . "']";
             if (isset($this->_submitValues[$base])) {
@@ -878,7 +878,7 @@ class HTML_QuickForm extends HTML_Common
                 }
             }
         }
-        
+
         // This is only supposed to work for groups with appendName = false
         if (null === $value && 'group' == $this->getElementType($elementName)) {
             $group    =& $this->getElement($elementName);
@@ -936,7 +936,7 @@ class HTML_QuickForm extends HTML_Common
             return $this->_errors[$element];
         }
     } // end func getElementError
-    
+
     // }}}
     // {{{ setElementError()
 
@@ -945,7 +945,7 @@ class HTML_QuickForm extends HTML_Common
      *
      * @param     string    $element    Name of form element to set error for
      * @param     string    $message    Error message, if empty then removes the current error message
-     * @since     1.0       
+     * @since     1.0
      * @access    public
      * @return    void
      */
@@ -957,7 +957,7 @@ class HTML_QuickForm extends HTML_Common
             unset($this->_errors[$element]);
         }
     } // end func setElementError
-         
+
      // }}}
      // {{{ getElementType()
 
@@ -1015,11 +1015,11 @@ class HTML_QuickForm extends HTML_Common
      * Removes an element
      *
      * The method "unlinks" an element from the form, returning the reference
-     * to the element object. If several elements named $elementName exist, 
+     * to the element object. If several elements named $elementName exist,
      * it removes the first one, leaving the others intact.
-     * 
+     *
      * @param string    $elementName The element name
-     * @param boolean   $removeRules True if rules for this element are to be removed too                     
+     * @param boolean   $removeRules True if rules for this element are to be removed too
      * @access public
      * @since 2.0
      * @return HTML_QuickForm_element    a reference to the removed element
@@ -1057,7 +1057,7 @@ class HTML_QuickForm extends HTML_Common
      * Adds a validation rule for the given field
      *
      * If the element is in fact a group, it will be considered as a whole.
-     * To validate grouped elements as separated entities, 
+     * To validate grouped elements as separated entities,
      * use addGroupRule instead of addRule.
      *
      * @param    string     $element       Form element name
@@ -1161,7 +1161,7 @@ class HTML_QuickForm extends HTML_Common
 
                     $this->_rules[$elementName][] = array(
                                                         'type'        => $type,
-                                                        'format'      => $format, 
+                                                        'format'      => $format,
                                                         'message'     => $rule[0],
                                                         'validation'  => $validation,
                                                         'reset'       => $reset,
@@ -1198,7 +1198,7 @@ class HTML_QuickForm extends HTML_Common
             }
 
             $this->_rules[$group][] = array('type'       => $type,
-                                            'format'     => $format, 
+                                            'format'     => $format,
                                             'message'    => $arg1,
                                             'validation' => $validation,
                                             'howmany'    => $howmany,
@@ -1216,13 +1216,13 @@ class HTML_QuickForm extends HTML_Common
     // {{{ addFormRule()
 
    /**
-    * Adds a global validation rule 
-    * 
+    * Adds a global validation rule
+    *
     * This should be used when for a rule involving several fields or if
     * you want to use some completely custom validation for your form.
-    * The rule function/method should return true in case of successful 
+    * The rule function/method should return true in case of successful
     * validation and array('element name' => 'error') when there were errors.
-    * 
+    *
     * @access   public
     * @param    mixed   Callback, either function name or array(&$object, 'method')
     * @param    string  $format   (optional)Required for extra rule data
@@ -1235,7 +1235,7 @@ class HTML_QuickForm extends HTML_Common
         }
         $this->_formRules[] = array($rule,$format);
     }
-    
+
     // }}}
     // {{{ applyFilter()
 
@@ -1266,7 +1266,7 @@ class HTML_QuickForm extends HTML_Common
                         $this->_submitValues[$elName] = $this->_recursiveFilter($filter, $value);
                     } else {
                         $idx  = "['" . str_replace(
-                                    array('\\', '\'', ']', '['), array('\\\\', '\\\'', '', "']['"), 
+                                    array('\\', '\'', ']', '['), array('\\\\', '\\\'', '', "']['"),
                                     $elName
                                 ) . "']";
                         eval("\$this->_submitValues{$idx} = \$this->_recursiveFilter(\$filter, \$value);");
@@ -1473,7 +1473,7 @@ class HTML_QuickForm extends HTML_Common
         $this->_jsPrefix = $pref;
         $this->_jsPostfix = $post;
     } // end func setJsWarnings
-    
+
     // }}}
     // {{{ setRequiredNote()
 
@@ -1517,7 +1517,7 @@ class HTML_QuickForm extends HTML_Common
      */
     function validate()
     {
-        if (count($this->_rules) == 0 && count($this->_formRules) == 0 && 
+        if (count($this->_rules) == 0 && count($this->_formRules) == 0 &&
             $this->isSubmitted()) {
             return (0 == count($this->_errors));
         } elseif (!$this->isSubmitted()) {
@@ -1545,7 +1545,7 @@ class HTML_QuickForm extends HTML_Common
                     // See also bug #12014, we should only consider a file that has
                     // status UPLOAD_ERR_NO_FILE as not uploaded, in all other cases
                     // validation should be performed, so that e.g. 'maxfilesize' rule
-                    // will display an error if status is UPLOAD_ERR_INI_SIZE 
+                    // will display an error if status is UPLOAD_ERR_INI_SIZE
                     // or UPLOAD_ERR_FORM_SIZE
                     } elseif (is_array($submitValue)) {
                         if (false === ($pos = strpos($target, '['))) {
@@ -1553,10 +1553,10 @@ class HTML_QuickForm extends HTML_Common
                         } else {
                             $base = str_replace(
                                         array('\\', '\''), array('\\\\', '\\\''),
-                                        substr($target, 0, $pos) 
-                                    ); 
+                                        substr($target, 0, $pos)
+                                    );
                             $idx  = "['" . str_replace(
-                                        array('\\', '\'', ']', '['), array('\\\\', '\\\'', '', "']['"), 
+                                        array('\\', '\'', ']', '['), array('\\\\', '\\\'', '', "']['"),
                                         substr($target, $pos + 1, -1)
                                     ) . "']";
                             eval("\$isUpload = isset(\$this->_submitFiles['{$base}']['name']{$idx});");
@@ -1639,7 +1639,7 @@ class HTML_QuickForm extends HTML_Common
         }
         return true;
     } // end func freeze
-        
+
     // }}}
     // {{{ isFrozen()
 
@@ -1819,7 +1819,7 @@ class HTML_QuickForm extends HTML_Common
         if (count($test) > 0) {
             return
                 "\n<script type=\"text/javascript\">\n" .
-                "//<![CDATA[\n" . 
+                "//<![CDATA[\n" .
                 "function validate_" . $this->_attributes['id'] . "(frm) {\n" .
                 "  var value = '';\n" .
                 "  var errFlag = new Array();\n" .
@@ -1863,7 +1863,7 @@ class HTML_QuickForm extends HTML_Common
      * Returns the form's contents in an array.
      *
      * The description of the array structure is in HTML_QuickForm_Renderer_Array docs
-     * 
+     *
      * @since     2.0
      * @access    public
      * @param     bool      Whether to collect hidden elements (passed to the Renderer's constructor)
@@ -1882,7 +1882,7 @@ class HTML_QuickForm extends HTML_Common
 
     /**
      * Returns a 'safe' element's value
-     * 
+     *
      * This method first tries to find a cleaned-up submitted value,
      * it will return a value set by setValue()/setDefaults()/setConstants()
      * if submitted value does not exist for the given element.
@@ -1918,9 +1918,9 @@ class HTML_QuickForm extends HTML_Common
     /**
      * Returns 'safe' elements' values
      *
-     * Unlike getSubmitValues(), this will return only the values 
+     * Unlike getSubmitValues(), this will return only the values
      * corresponding to the elements present in the form.
-     * 
+     *
      * @param   mixed   Array/string of element names, whose values we want. If not set then return all elements.
      * @access  public
      * @return  array   An assoc array of elements' values
@@ -1936,7 +1936,7 @@ class HTML_QuickForm extends HTML_Common
                 $fldName = null;
                 if ( isset( $this->_elements[$key]->_attributes['name'] ) ) {
 					//filter the value across XSS vulnerability issues.
-					$fldName = $this->_elements[$key]->_attributes['name'];                
+					$fldName = $this->_elements[$key]->_attributes['name'];
 				}
                 if (
                     // if not a text/textarea…
@@ -1952,7 +1952,7 @@ class HTML_QuickForm extends HTML_Common
                     //so we should iterate and get filtered value.
                     CRM_Core_HTMLInputCoder::encodeInput( $value );
                 }
-                
+
                 if (is_array($value)) {
                     // This shit throws a bogus warning in PHP 4.3.x
                     $values = HTML_QuickForm::arrayMerge($values, $value);
@@ -1964,12 +1964,12 @@ class HTML_QuickForm extends HTML_Common
             }
             foreach ($elementList as $elementName) {
                 $value = $this->exportValue($elementName);
-                                
+
                 //filter the value across XSS vulnerability issues.
                 if ( ! CRM_Core_HTMLInputCoder::isSkippedField($elementName)) {
                     CRM_Core_HTMLInputCoder::encodeInput( $value );
                 }
-                
+
                 if (PEAR::isError($value)) {
                     return $value;
                 }

--- a/HTML/QuickForm/Action.php
+++ b/HTML/QuickForm/Action.php
@@ -3,7 +3,7 @@
 
 /**
  * Class representing an action to perform on HTTP request.
- * 
+ *
  * PHP versions 4 and 5
  *
  * LICENSE: This source file is subject to version 3.01 of the PHP license
@@ -22,10 +22,10 @@
  */
 
 /**
- * Class representing an action to perform on HTTP request. 
- * 
+ * Class representing an action to perform on HTTP request.
+ *
  * The Controller will select the appropriate Action to call on the request and
- * call its perform() method. The subclasses of this class should implement all 
+ * call its perform() method. The subclasses of this class should implement all
  * the necessary business logic.
  *
  * @category    HTML

--- a/HTML/QuickForm/Action/Back.php
+++ b/HTML/QuickForm/Action/Back.php
@@ -3,7 +3,7 @@
 
 /**
  * The action for a 'back' button of wizard-type multipage form.
- * 
+ *
  * PHP versions 4 and 5
  *
  * LICENSE: This source file is subject to version 3.01 of the PHP license

--- a/HTML/QuickForm/Action/Direct.php
+++ b/HTML/QuickForm/Action/Direct.php
@@ -3,7 +3,7 @@
 
 /**
  * This action allows to go to a specific page of a multipage form.
- * 
+ *
  * PHP versions 4 and 5
  *
  * LICENSE: This source file is subject to version 3.01 of the PHP license

--- a/HTML/QuickForm/Action/Display.php
+++ b/HTML/QuickForm/Action/Display.php
@@ -3,7 +3,7 @@
 
 /**
  * This action handles output of the form.
- * 
+ *
  * PHP versions 4 and 5
  *
  * LICENSE: This source file is subject to version 3.01 of the PHP license

--- a/HTML/QuickForm/Action/Next.php
+++ b/HTML/QuickForm/Action/Next.php
@@ -3,7 +3,7 @@
 
 /**
  * The action for a 'next' button of wizard-type multipage form.
- * 
+ *
  * PHP versions 4 and 5
  *
  * LICENSE: This source file is subject to version 3.01 of the PHP license

--- a/HTML/QuickForm/Action/Submit.php
+++ b/HTML/QuickForm/Action/Submit.php
@@ -3,7 +3,7 @@
 
 /**
  * The action for a 'submit' button.
- * 
+ *
  * PHP versions 4 and 5
  *
  * LICENSE: This source file is subject to version 3.01 of the PHP license

--- a/HTML/QuickForm/Controller.php
+++ b/HTML/QuickForm/Controller.php
@@ -3,7 +3,7 @@
 
 /**
  * The class representing a Controller of MVC design pattern.
- * 
+ *
  * PHP versions 4 and 5
  *
  * LICENSE: This source file is subject to version 3.01 of the PHP license
@@ -218,7 +218,6 @@ class HTML_QuickForm_Controller
         } // switch
     }
 
-
    /**
     * Checks whether the form is modal.
     *
@@ -253,7 +252,7 @@ class HTML_QuickForm_Controller
                     // Fix for bug #8687: the unseen page was considered
                     // submitted, so defaults for checkboxes and multiselects
                     // were not used. Shouldn't break anything since this flag
-                    // will be reset right below in loadValues(). 
+                    // will be reset right below in loadValues().
                     $page->_flagSubmitted = false;
                     // Use controller's defaults and constants, if present
                     $this->applyDefaults($key);

--- a/HTML/QuickForm/Page.php
+++ b/HTML/QuickForm/Page.php
@@ -3,7 +3,7 @@
 
 /**
  * Class representing a page of a multipage form.
- * 
+ *
  * PHP versions 4 and 5
  *
  * LICENSE: This source file is subject to version 3.01 of the PHP license

--- a/HTML/QuickForm/Renderer.php
+++ b/HTML/QuickForm/Renderer.php
@@ -3,7 +3,7 @@
 
 /**
  * An abstract base class for QuickForm renderers
- * 
+ *
  * PHP versions 4 and 5
  *
  * LICENSE: This source file is subject to version 3.01 of the PHP license
@@ -23,7 +23,7 @@
 
 /**
  * An abstract base class for QuickForm renderers
- * 
+ *
  * The class implements a Visitor design pattern
  *
  * @category    HTML
@@ -49,7 +49,7 @@ class HTML_QuickForm_Renderer
     *
     * @param    HTML_QuickForm  a form being visited
     * @access   public
-    * @return   void 
+    * @return   void
     * @abstract
     */
     function startForm(&$form)
@@ -59,10 +59,10 @@ class HTML_QuickForm_Renderer
 
    /**
     * Called when visiting a form, after processing all form elements
-    * 
+    *
     * @param    HTML_QuickForm  a form being visited
     * @access   public
-    * @return   void 
+    * @return   void
     * @abstract
     */
     function finishForm(&$form)
@@ -75,7 +75,7 @@ class HTML_QuickForm_Renderer
     *
     * @param    HTML_QuickForm_header   a header element being visited
     * @access   public
-    * @return   void 
+    * @return   void
     * @abstract
     */
     function renderHeader(&$header)
@@ -90,7 +90,7 @@ class HTML_QuickForm_Renderer
     * @param    bool                    Whether an element is required
     * @param    string                  An error message associated with an element
     * @access   public
-    * @return   void 
+    * @return   void
     * @abstract
     */
     function renderElement(&$element, $required, $error)
@@ -100,11 +100,11 @@ class HTML_QuickForm_Renderer
 
    /**
     * Called when visiting a hidden element
-    * 
+    *
     * @param    HTML_QuickForm_element  a hidden element being visited
     * @access   public
     * @return   void
-    * @abstract 
+    * @abstract
     */
     function renderHidden(&$element)
     {
@@ -113,13 +113,13 @@ class HTML_QuickForm_Renderer
 
    /**
     * Called when visiting a raw HTML/text pseudo-element
-    * 
-    * Only implemented in Default renderer. Usage of 'html' elements is 
+    *
+    * Only implemented in Default renderer. Usage of 'html' elements is
     * discouraged, templates should be used instead.
     *
     * @param    HTML_QuickForm_html     a 'raw html' element being visited
     * @access   public
-    * @return   void 
+    * @return   void
     * @abstract
     */
     function renderHtml(&$data)
@@ -134,7 +134,7 @@ class HTML_QuickForm_Renderer
     * @param    bool                    Whether a group is required
     * @param    string                  An error message associated with a group
     * @access   public
-    * @return   void 
+    * @return   void
     * @abstract
     */
     function startGroup(&$group, $required, $error)
@@ -147,7 +147,7 @@ class HTML_QuickForm_Renderer
     *
     * @param    HTML_QuickForm_group    A group being visited
     * @access   public
-    * @return   void 
+    * @return   void
     * @abstract
     */
     function finishGroup(&$group)

--- a/HTML/QuickForm/Renderer/Array.php
+++ b/HTML/QuickForm/Renderer/Array.php
@@ -3,7 +3,7 @@
 
 /**
  * A concrete renderer for HTML_QuickForm, makes an array of form contents
- * 
+ *
  * PHP versions 4 and 5
  *
  * LICENSE: This source file is subject to version 3.01 of the PHP license
@@ -229,10 +229,10 @@ class HTML_QuickForm_Renderer_Array extends HTML_QuickForm_Renderer
     function renderHidden(&$element, $required = FALSE, $error = FALSE)
     {
         if ($this->_collectHidden) {
-            // add to error array 
-            if (!empty($error)) { 
-                $this->_ary['errors']['hidden'] = $error; 
-            } 
+            // add to error array
+            if (!empty($error)) {
+                $this->_ary['errors']['hidden'] = $error;
+            }
             $this->_ary['hidden'] .= $element->toHtml() . "\n";
         } else {
             $this->renderElement($element, $required, $error);

--- a/HTML/QuickForm/Renderer/ArraySmarty.php
+++ b/HTML/QuickForm/Renderer/ArraySmarty.php
@@ -4,7 +4,7 @@
 /**
  * A static renderer for HTML_QuickForm, makes an array of form content
  * useful for a Smarty template
- * 
+ *
  * PHP versions 4 and 5
  *
  * LICENSE: This source file is subject to version 3.01 of the PHP license
@@ -26,7 +26,7 @@
 
 /**
  * A concrete renderer for HTML_QuickForm, makes an array of form contents
- */ 
+ */
 require_once 'HTML/QuickForm/Renderer/Array.php';
 
 /**
@@ -202,11 +202,11 @@ class HTML_QuickForm_Renderer_ArraySmarty extends HTML_QuickForm_Renderer_Array
         }
         // create keys for elements grouped by native group or name
         if (strstr($ret['name'], '[') or $this->_currentGroup) {
-            // Fix for bug #8123: escape backslashes and quotes to prevent errors 
+            // Fix for bug #8123: escape backslashes and quotes to prevent errors
             // in eval(). The code below seems to handle the case where element
             // name has unbalanced square brackets. Dunno whether we really
             // need this after the fix for #8123, but I'm wary of making big
-            // changes to this code.  
+            // changes to this code.
             preg_match('/([^]]*)\\[([^]]*)\\]/', $ret['name'], $matches);
             if (isset($matches[1])) {
                 $sKeysSub = substr_replace($ret['name'], '', 0, strlen($matches[1]));

--- a/HTML/QuickForm/Renderer/Default.php
+++ b/HTML/QuickForm/Renderer/Default.php
@@ -3,7 +3,7 @@
 
 /**
  * A concrete renderer for HTML_QuickForm, based on QuickForm 2.x built-in one
- * 
+ *
  * PHP versions 4 and 5
  *
  * LICENSE: This source file is subject to version 3.01 of the PHP license
@@ -30,7 +30,7 @@ require_once 'HTML/QuickForm/Renderer.php';
 
 /**
  * A concrete renderer for HTML_QuickForm, based on QuickForm 2.x built-in one
- * 
+ *
  * @category    HTML
  * @package     HTML_QuickForm
  * @author      Alexey Borzov <avb@php.net>
@@ -42,7 +42,7 @@ require_once 'HTML/QuickForm/Renderer.php';
 class HTML_QuickForm_Renderer_Default extends HTML_QuickForm_Renderer
 {
    /**
-    * The HTML of the form  
+    * The HTML of the form
     * @var      string
     * @access   private
     */
@@ -53,7 +53,7 @@ class HTML_QuickForm_Renderer_Default extends HTML_QuickForm_Renderer
     * @var      string
     * @access   private
     */
-    var $_headerTemplate = 
+    var $_headerTemplate =
         "\n\t<tr>\n\t\t<td style=\"white-space: nowrap; background-color: #CCCCCC;\" align=\"left\" valign=\"top\" colspan=\"2\"><b>{header}</b></td>\n\t</tr>";
 
    /**
@@ -61,7 +61,7 @@ class HTML_QuickForm_Renderer_Default extends HTML_QuickForm_Renderer
     * @var      string
     * @access   private
     */
-    var $_elementTemplate = 
+    var $_elementTemplate =
         "\n\t<tr>\n\t\t<td align=\"right\" valign=\"top\"><!-- BEGIN required --><span style=\"color: #ff0000\">*</span><!-- END required --><b>{label}</b></td>\n\t\t<td valign=\"top\" align=\"left\"><!-- BEGIN error --><span style=\"color: #ff0000\">{error}</span><br /><!-- END error -->\t{element}</td>\n\t</tr>";
 
    /**
@@ -69,7 +69,7 @@ class HTML_QuickForm_Renderer_Default extends HTML_QuickForm_Renderer
     * @var      string
     * @access   private
     */
-    var $_formTemplate = 
+    var $_formTemplate =
         "\n<form{attributes}>\n<div>\n{hidden}<table border=\"0\">\n{content}\n</table>\n</div>\n</form>";
 
    /**
@@ -77,7 +77,7 @@ class HTML_QuickForm_Renderer_Default extends HTML_QuickForm_Renderer
     * @var      string
     * @access   private
     */
-    var $_requiredNoteTemplate = 
+    var $_requiredNoteTemplate =
         "\n\t<tr>\n\t\t<td></td>\n\t<td align=\"left\" valign=\"top\">{requiredNote}</td>\n\t</tr>";
 
    /**
@@ -89,10 +89,10 @@ class HTML_QuickForm_Renderer_Default extends HTML_QuickForm_Renderer
 
    /**
     * Array containing the templates for group wraps.
-    * 
+    *
     * These templates are wrapped around group elements and groups' own
     * templates wrap around them. This is set by setGroupTemplate().
-    * 
+    *
     * @var      array
     * @access   private
     */
@@ -106,7 +106,7 @@ class HTML_QuickForm_Renderer_Default extends HTML_QuickForm_Renderer
     var $_groupTemplates = array();
 
    /**
-    * True if we are inside a group 
+    * True if we are inside a group
     * @var      bool
     * @access   private
     */
@@ -139,7 +139,7 @@ class HTML_QuickForm_Renderer_Default extends HTML_QuickForm_Renderer
     * @access   private
     */
     var $_groupTemplate = '';
-    
+
    /**
     * Collected HTML of the hidden fields
     * @var      string
@@ -169,7 +169,7 @@ class HTML_QuickForm_Renderer_Default extends HTML_QuickForm_Renderer
         // finishForm() was not called (e.g. group::toHtml(), bug #3511)
         return $this->_hiddenHtml . $this->_html;
     } // end func toHtml
-    
+
    /**
     * Called when visiting a form, before processing any form elements
     *
@@ -186,7 +186,7 @@ class HTML_QuickForm_Renderer_Default extends HTML_QuickForm_Renderer
    /**
     * Called when visiting a form, after processing all form elements
     * Adds required note, form attributes, validation javascript and form content.
-    * 
+    *
     * @param    HTML_QuickForm  form object being visited
     * @access   public
     * @return   void
@@ -211,7 +211,7 @@ class HTML_QuickForm_Renderer_Default extends HTML_QuickForm_Renderer
             $this->_html = $script . "\n" . $this->_html;
         }
     } // end func finishForm
-      
+
    /**
     * Called when visiting a header element
     *
@@ -292,7 +292,7 @@ class HTML_QuickForm_Renderer_Default extends HTML_QuickForm_Renderer
     function renderElement(&$element, $required, $error)
     {
         // make sure that all elements are id'ed even in a group!
-        
+
         CRM_Core_Form_Renderer::updateAttributes( $element, $required, $error );
 
         if (!$this->_inGroup) {
@@ -313,11 +313,11 @@ class HTML_QuickForm_Renderer_Default extends HTML_QuickForm_Renderer
             $this->_groupElements[] = $element->toHtml();
         }
     } // end func renderElement
-   
+
    /**
     * Renders an hidden element
     * Called when visiting a hidden element
-    * 
+    *
     * @param HTML_QuickForm_element     form element being visited
     * @access public
     * @return void
@@ -329,7 +329,7 @@ class HTML_QuickForm_Renderer_Default extends HTML_QuickForm_Renderer
 
    /**
     * Called when visiting a raw HTML/text pseudo-element
-    * 
+    *
     * @param  HTML_QuickForm_html   element being visited
     * @access public
     * @return void
@@ -388,9 +388,9 @@ class HTML_QuickForm_Renderer_Default extends HTML_QuickForm_Renderer
     } // end func finishGroup
 
     /**
-     * Sets element template 
+     * Sets element template
      *
-     * @param       string      The HTML surrounding an element 
+     * @param       string      The HTML surrounding an element
      * @param       string      (optional) Name of the element to apply template for
      * @access      public
      * @return      void
@@ -406,9 +406,9 @@ class HTML_QuickForm_Renderer_Default extends HTML_QuickForm_Renderer
 
 
     /**
-     * Sets template for a group wrapper 
-     * 
-     * This template is contained within a group-as-element template 
+     * Sets template for a group wrapper
+     *
+     * This template is contained within a group-as-element template
      * set via setTemplate() and contains group's element templates, set
      * via setGroupElementTemplate()
      *
@@ -425,7 +425,7 @@ class HTML_QuickForm_Renderer_Default extends HTML_QuickForm_Renderer
     /**
      * Sets element template for elements within a group
      *
-     * @param       string      The HTML surrounding an element 
+     * @param       string      The HTML surrounding an element
      * @param       string      Name of the group to apply template for
      * @access      public
      * @return      void
@@ -438,7 +438,7 @@ class HTML_QuickForm_Renderer_Default extends HTML_QuickForm_Renderer
     /**
      * Sets header template
      *
-     * @param       string      The HTML surrounding the header 
+     * @param       string      The HTML surrounding the header
      * @access      public
      * @return      void
      */
@@ -448,9 +448,9 @@ class HTML_QuickForm_Renderer_Default extends HTML_QuickForm_Renderer
     } // end func setHeaderTemplate
 
     /**
-     * Sets form template 
+     * Sets form template
      *
-     * @param     string    The HTML surrounding the form tags 
+     * @param     string    The HTML surrounding the form tags
      * @access    public
      * @return    void
      */
@@ -462,7 +462,7 @@ class HTML_QuickForm_Renderer_Default extends HTML_QuickForm_Renderer
     /**
      * Sets the note indicating required fields template
      *
-     * @param       string      The HTML surrounding the required note 
+     * @param       string      The HTML surrounding the required note
      * @access      public
      * @return      void
      */

--- a/HTML/QuickForm/Renderer/ITDynamic.php
+++ b/HTML/QuickForm/Renderer/ITDynamic.php
@@ -3,7 +3,7 @@
 
 /**
  * A concrete renderer for HTML_QuickForm, using Integrated Templates.
- * 
+ *
  * PHP versions 4 and 5
  *
  * LICENSE: This source file is subject to version 3.01 of the PHP license
@@ -28,15 +28,15 @@ require_once 'HTML/QuickForm/Renderer.php';
 
 /**
  * A concrete renderer for HTML_QuickForm, using Integrated Templates.
- * 
- * This is a "dynamic" renderer, which means that concrete form look 
- * is defined at runtime. This also means that you can define 
+ *
+ * This is a "dynamic" renderer, which means that concrete form look
+ * is defined at runtime. This also means that you can define
  * <b>one</b> template file for <b>all</b> your forms. That template
- * should contain a block for every element 'look' appearing in your 
+ * should contain a block for every element 'look' appearing in your
  * forms and also some special blocks (consult the examples). If a
  * special block is not set for an element, the renderer falls back to
  * a default one.
- * 
+ *
  * @category    HTML
  * @package     HTML_QuickForm
  * @author      Alexey Borzov <avb@php.net>
@@ -79,7 +79,7 @@ class HTML_QuickForm_Renderer_ITDynamic extends HTML_QuickForm_Renderer
     var $_groupElementIdx = 0;
 
    /**
-    * Blocks to use for different elements  
+    * Blocks to use for different elements
     * @var array
     */
     var $_elementBlocks = array();
@@ -123,7 +123,7 @@ class HTML_QuickForm_Renderer_ITDynamic extends HTML_QuickForm_Renderer
         // assign javascript validation rules
         $this->_tpl->setVariable('qf_javascript', $form->getValidationScript());
     }
-      
+
 
     function renderHeader(&$header)
     {
@@ -190,7 +190,7 @@ class HTML_QuickForm_Renderer_ITDynamic extends HTML_QuickForm_Renderer
         $this->_tpl->parse($blockName);
         $this->_tpl->parseCurrentBlock();
     }
-   
+
 
     function renderHidden(&$element)
     {
@@ -234,11 +234,11 @@ class HTML_QuickForm_Renderer_ITDynamic extends HTML_QuickForm_Renderer
 
    /**
     * Returns the name of a block to use for element rendering
-    * 
+    *
     * If a name was not explicitly set via setElementBlock(), it tries
     * the names '{prefix}_{element type}' and '{prefix}_{element}', where
     * prefix is either 'qf' or the name of the current group's block
-    * 
+    *
     * @param HTML_QuickForm_element     form element being rendered
     * @access private
     * @return string    block name
@@ -269,7 +269,7 @@ class HTML_QuickForm_Renderer_ITDynamic extends HTML_QuickForm_Renderer
 
    /**
     * Sets the block to use for element rendering
-    * 
+    *
     * @param mixed      element name or array ('element name' => 'block name')
     * @param string     block name if $elementName is not an array
     * @access public

--- a/HTML/QuickForm/Renderer/ITStatic.php
+++ b/HTML/QuickForm/Renderer/ITStatic.php
@@ -2,9 +2,9 @@
 /* vim: set expandtab tabstop=4 shiftwidth=4 softtabstop=4: */
 
 /**
- * A static renderer for HTML_QuickForm compatible 
+ * A static renderer for HTML_QuickForm compatible
  * with HTML_Template_IT and HTML_Template_Sigma.
- * 
+ *
  * PHP versions 4 and 5
  *
  * LICENSE: This source file is subject to version 3.01 of the PHP license
@@ -28,13 +28,13 @@
 require_once 'HTML/QuickForm/Renderer.php';
 
 /**
- * A static renderer for HTML_QuickForm compatible 
+ * A static renderer for HTML_QuickForm compatible
  * with HTML_Template_IT and HTML_Template_Sigma.
  *
  * As opposed to the dynamic renderer, this renderer needs
  * every elements and labels in the form to be specified by
  * placeholders at the position you want them to be displayed.
- * 
+ *
  * @category    HTML
  * @package     HTML_QuickForm
  * @author      Bertrand Mansion <bmansion@mamasam.com>
@@ -101,7 +101,7 @@ class HTML_QuickForm_Renderer_ITStatic extends HTML_QuickForm_Renderer
     var $_error = '<font color="red">{error}</font><br />{html}';
 
    /**
-    * Collected HTML for hidden elements, if needed  
+    * Collected HTML for hidden elements, if needed
     * @var string
     */
     var $_hidden = '';
@@ -139,7 +139,7 @@ class HTML_QuickForm_Renderer_ITStatic extends HTML_QuickForm_Renderer
 
    /**
     * Called when visiting a form, after processing all form elements
-    * 
+    *
     * @param    HTML_QuickForm  form object being visited
     * @access   public
     * @return   void
@@ -264,7 +264,7 @@ class HTML_QuickForm_Renderer_ITStatic extends HTML_QuickForm_Renderer
 
    /**
     * Called when visiting a hidden element
-    * 
+    *
     * @param    HTML_QuickForm_element  hidden element being visited
     * @access   public
     * @return   void

--- a/HTML/QuickForm/Renderer/Object.php
+++ b/HTML/QuickForm/Renderer/Object.php
@@ -3,7 +3,7 @@
 
 /**
  * A concrete renderer for HTML_QuickForm, makes an object from form contents
- * 
+ *
  * PHP versions 4 and 5
  *
  * LICENSE: This source file is subject to version 3.01 of the PHP license
@@ -73,7 +73,7 @@ class HTML_QuickForm_Renderer_Object extends HTML_QuickForm_Renderer
     var $_elementType = 'QuickFormElement';
 
     /**
-    * Additional style information for different elements  
+    * Additional style information for different elements
     * @var array $_elementStyles
     */
     var $_elementStyles = array();
@@ -103,7 +103,7 @@ class HTML_QuickForm_Renderer_Object extends HTML_QuickForm_Renderer
      * Return the rendered Object
      * @access public
      */
-    function toObject() 
+    function toObject()
     {
         return $this->_obj;
     }
@@ -118,7 +118,7 @@ class HTML_QuickForm_Renderer_Object extends HTML_QuickForm_Renderer
         $this->_elementType = $type;
     }
 
-    function startForm(&$form) 
+    function startForm(&$form)
     {
         $this->_obj->frozen = $form->isFrozen();
         $this->_obj->javascript = $form->getValidationScript();
@@ -134,7 +134,7 @@ class HTML_QuickForm_Renderer_Object extends HTML_QuickForm_Renderer
         $this->_sectionCount = 0;
     } // end func startForm
 
-    function renderHeader(&$header) 
+    function renderHeader(&$header)
     {
         $hobj = new StdClass;
         $hobj->header = $header->toHtml();
@@ -142,7 +142,7 @@ class HTML_QuickForm_Renderer_Object extends HTML_QuickForm_Renderer
         $this->_currentSection = $this->_sectionCount++;
     }
 
-    function renderElement(&$element, $required, $error) 
+    function renderElement(&$element, $required, $error)
     {
         $elObj = $this->_elementToObject($element, $required, $error);
         if(!empty($error)) {
@@ -161,7 +161,7 @@ class HTML_QuickForm_Renderer_Object extends HTML_QuickForm_Renderer
         }
     } //end func renderHidden
 
-    function startGroup(&$group, $required, $error) 
+    function startGroup(&$group, $required, $error)
     {
         $this->_currentGroup = $this->_elementToObject($group, $required, $error);
         if(!empty($error)) {
@@ -170,7 +170,7 @@ class HTML_QuickForm_Renderer_Object extends HTML_QuickForm_Renderer
         }
     } // end func startGroup
 
-    function finishGroup(&$group) 
+    function finishGroup(&$group)
     {
         $this->_storeObject($this->_currentGroup);
         $this->_currentGroup = null;
@@ -185,7 +185,7 @@ class HTML_QuickForm_Renderer_Object extends HTML_QuickForm_Renderer
      * @param error string    Error associated with the element
      * @return object
      */
-    function _elementToObject(&$element, $required, $error) 
+    function _elementToObject(&$element, $required, $error)
     {
         if($this->_elementType) {
             $ret = new $this->_elementType;
@@ -220,14 +220,14 @@ class HTML_QuickForm_Renderer_Object extends HTML_QuickForm_Renderer
         return $ret;
     }
 
-    /** 
+    /**
      * Stores an object representation of an element in the form array
      *
      * @access private
      * @param QuickformElement     Object representation of an element
      * @return void
      */
-    function _storeObject($elObj) 
+    function _storeObject($elObj)
     {
         $name = $elObj->name;
         if(is_object($this->_currentGroup) && $elObj->type != 'group') {
@@ -254,9 +254,9 @@ class HTML_QuickForm_Renderer_Object extends HTML_QuickForm_Renderer
 
 /**
  * Convenience class for the form object passed to outputObject()
- * 
+ *
  * Eg.
- * <pre>  
+ * <pre>
  * {form.outputJavaScript():h}
  * {form.outputHeader():h}
  *   <table>
@@ -266,7 +266,7 @@ class HTML_QuickForm_Renderer_Object extends HTML_QuickForm_Renderer
  *   </table>
  * </form>
  * </pre>
- * 
+ *
  * @category    HTML
  * @package     HTML_QuickForm
  * @author      Ron McClain <ron@humaniq.com>
@@ -306,7 +306,7 @@ class QuickformForm
     var $hidden;
 
    /**
-    * Set if there were validation errors.  
+    * Set if there were validation errors.
     * StdClass object with element names for keys and their
     * error messages as values
     * @var object $errors
@@ -315,7 +315,7 @@ class QuickformForm
 
    /**
     * Array of QuickformElementObject elements.  If there are headers in the form
-    * this will be empty and the elements will be in the 
+    * this will be empty and the elements will be in the
     * separate sections
     * @var array $elements
     */
@@ -329,7 +329,7 @@ class QuickformForm
 
    /**
     * Output &lt;form&gt; header
-    * {form.outputHeader():h} 
+    * {form.outputHeader():h}
     * @return string    &lt;form attributes&gt;
     */
     function outputHeader()
@@ -352,7 +352,7 @@ class QuickformForm
 /**
  * Convenience class describing a form element.
  *
- * The properties defined here will be available from 
+ * The properties defined here will be available from
  * your flexy templates by referencing
  * {form.zip.label:h}, {form.zip.html:h}, etc.
  *

--- a/HTML/QuickForm/Renderer/ObjectFlexy.php
+++ b/HTML/QuickForm/Renderer/ObjectFlexy.php
@@ -3,7 +3,7 @@
 
 /**
  * QuickForm renderer for Flexy template engine, static version.
- * 
+ *
  * PHP versions 4 and 5
  *
  * LICENSE: This source file is subject to version 3.01 of the PHP license
@@ -23,12 +23,12 @@
 
 /**
  * A concrete renderer for HTML_QuickForm, makes an object from form contents
- */ 
+ */
 require_once 'HTML/QuickForm/Renderer/Object.php';
 
 /**
  * QuickForm renderer for Flexy template engine, static version.
- * 
+ *
  * A static renderer for HTML_Quickform.  Makes a QuickFormFlexyObject
  * from the form content suitable for use with a Flexy template
  *
@@ -159,7 +159,7 @@ class HTML_QuickForm_Renderer_ObjectFlexy extends HTML_QuickForm_Renderer_Object
                 $keys = '->{\'' . str_replace(array('\\', '\''), array('\\\\', '\\\''), $ret->name) . '\'}';
             } else {
                 $keys = '->{\'' . str_replace(
-                            array('\\', '\'', '[', ']'), array('\\\\', '\\\'', '\'}->{\'', ''), 
+                            array('\\', '\'', '[', ']'), array('\\\\', '\\\'', '\'}->{\'', ''),
                             $ret->name
                         ) . '\'}';
             }
@@ -190,14 +190,14 @@ class HTML_QuickForm_Renderer_ObjectFlexy extends HTML_QuickForm_Renderer_Object
     }
 
     /**
-     * Stores an object representation of an element in the 
+     * Stores an object representation of an element in the
      * QuickformFormObject instance
      *
      * @access private
      * @param QuickformElement  Object representation of an element
      * @return void
      */
-    function _storeObject($elObj) 
+    function _storeObject($elObj)
     {
         if ($elObj) {
             $keys = $elObj->keys;
@@ -230,7 +230,7 @@ class HTML_QuickForm_Renderer_ObjectFlexy extends HTML_QuickForm_Renderer_Object
     function setHtmlTemplate($template)
     {
         $this->_html = $template;
-    } 
+    }
 
     /**
      * Set the filename of the template to render form labels
@@ -249,7 +249,7 @@ class HTML_QuickForm_Renderer_ObjectFlexy extends HTML_QuickForm_Renderer_Object
      * @param string   Filename of template
      * @return void
      */
-    function setLabelTemplate($template) 
+    function setLabelTemplate($template)
     {
         $this->_label = $template;
     }

--- a/HTML/QuickForm/Renderer/QuickHtml.php
+++ b/HTML/QuickForm/Renderer/QuickHtml.php
@@ -3,7 +3,7 @@
 
 /**
  * A renderer that makes it quick and easy to create customized forms.
- * 
+ *
  * PHP versions 4 and 5
  *
  * LICENSE: This source file is subject to version 3.01 of the PHP license
@@ -23,7 +23,7 @@
 
 /**
  * A concrete renderer for HTML_QuickForm, based on QuickForm 2.x built-in one
- */ 
+ */
 require_once 'HTML/QuickForm/Renderer/Default.php';
 
 /**
@@ -34,7 +34,7 @@ require_once 'HTML/QuickForm/Renderer/Default.php';
  * elements from their display, and being able to use QuickForm in
  * widget-based template systems.  See the online docs for more info.
  * For a usage example see: docs/renderers/QuickHtml_example.php
- * 
+ *
  * @category    HTML
  * @package     HTML_QuickForm
  * @author      Jason Rust <jrust@rustyparts.com>
@@ -52,7 +52,7 @@ class HTML_QuickForm_Renderer_QuickHtml extends HTML_QuickForm_Renderer_Default 
 
     // }}}
     // {{{ constructor
-    
+
     /**
      * Constructor
      *
@@ -112,7 +112,7 @@ class HTML_QuickForm_Renderer_QuickHtml extends HTML_QuickForm_Renderer_Default 
         $elementKey = null;
         // Find the key for the element
         foreach ($this->renderedElements as $key => $data) {
-            if ($data['name'] == $elementName && 
+            if ($data['name'] == $elementName &&
                 // See if the value must match as well
                 (is_null($elementValue) ||
                  $data['value'] == $elementValue)) {
@@ -122,12 +122,12 @@ class HTML_QuickForm_Renderer_QuickHtml extends HTML_QuickForm_Renderer_Default 
         }
 
         if (is_null($elementKey)) {
-            $msg = is_null($elementValue) ? "Element $elementName does not exist." : 
+            $msg = is_null($elementValue) ? "Element $elementName does not exist." :
                 "Element $elementName with value of $elementValue does not exist.";
             return PEAR::raiseError(null, QUICKFORM_UNREGISTERED_ELEMENT, null, E_USER_WARNING, $msg, 'HTML_QuickForm_Error', true);
         } else {
             if ($this->renderedElements[$elementKey]['rendered']) {
-                $msg = is_null($elementValue) ? "Element $elementName has already been rendered." : 
+                $msg = is_null($elementValue) ? "Element $elementName has already been rendered." :
                     "Element $elementName with value of $elementValue has already been rendered.";
                 return PEAR::raiseError(null, QUICKFORM_ERROR, null, E_USER_WARNING, $msg, 'HTML_QuickForm_Error', true);
             } else {
@@ -150,7 +150,7 @@ class HTML_QuickForm_Renderer_QuickHtml extends HTML_QuickForm_Renderer_Default 
      *
      * @access public
      * @return mixed HTML string of element if $immediateRender is set, else we just add the
-     *               html to the global _html string 
+     *               html to the global _html string
      */
     function renderElement(&$element, $required, $error)
     {
@@ -158,9 +158,9 @@ class HTML_QuickForm_Renderer_QuickHtml extends HTML_QuickForm_Renderer_Default 
         parent::renderElement($element, $required, $error);
         if (!$this->_inGroup) {
             $this->renderedElements[] = array(
-                    'name' => $element->getName(), 
-                    'value' => $element->getValue(), 
-                    'html' => $this->_html, 
+                    'name' => $element->getName(),
+                    'value' => $element->getValue(),
+                    'html' => $this->_html,
                     'rendered' => false);
         }
         $this->_html = '';
@@ -171,7 +171,7 @@ class HTML_QuickForm_Renderer_QuickHtml extends HTML_QuickForm_Renderer_Default 
 
     /**
      * Gets the html for a hidden element and adds it to the array.
-     * 
+     *
      * @param HTML_QuickForm_element    hidden form element being visited
      * @access public
      * @return void
@@ -179,12 +179,12 @@ class HTML_QuickForm_Renderer_QuickHtml extends HTML_QuickForm_Renderer_Default 
     function renderHidden(&$element)
     {
         $this->renderedElements[] = array(
-                'name' => $element->getName(), 
-                'value' => $element->getValue(), 
-                'html' => $element->toHtml(), 
+                'name' => $element->getName(),
+                'value' => $element->getValue(),
+                'html' => $element->toHtml(),
                 'rendered' => false);
     } // end func renderHidden
-    
+
     // }}}
     // {{{ finishGroup()
 
@@ -201,9 +201,9 @@ class HTML_QuickForm_Renderer_QuickHtml extends HTML_QuickForm_Renderer_Default 
         $this->_html = '';
         parent::finishGroup($group);
         $this->renderedElements[] = array(
-                'name' => $group->getName(), 
-                'value' => $group->getValue(), 
-                'html' => $this->_html, 
+                'name' => $group->getName(),
+                'value' => $group->getValue(),
+                'html' => $this->_html,
                 'rendered' => false);
         $this->_html = '';
     } // end func finishGroup

--- a/HTML/QuickForm/Rule.php
+++ b/HTML/QuickForm/Rule.php
@@ -2,8 +2,8 @@
 /* vim: set expandtab tabstop=4 shiftwidth=4 softtabstop=4: */
 
 /**
- * Abstract base class for QuickForm validation rules 
- * 
+ * Abstract base class for QuickForm validation rules
+ *
  * PHP versions 4 and 5
  *
  * LICENSE: This source file is subject to version 3.01 of the PHP license
@@ -22,7 +22,7 @@
  */
 
 /**
- * Abstract base class for QuickForm validation rules 
+ * Abstract base class for QuickForm validation rules
  *
  * @category    HTML
  * @package     HTML_QuickForm
@@ -46,7 +46,7 @@ class HTML_QuickForm_Rule
 
    /**
     * Validates a value
-    * 
+    *
     * @access public
     * @abstract
     */

--- a/HTML/QuickForm/Rule/Callback.php
+++ b/HTML/QuickForm/Rule/Callback.php
@@ -3,7 +3,7 @@
 
 /**
  * Validates values using callback functions or methods
- * 
+ *
  * PHP versions 4 and 5
  *
  * LICENSE: This source file is subject to version 3.01 of the PHP license
@@ -22,7 +22,7 @@
  */
 
 /**
- * Abstract base class for QuickForm validation rules 
+ * Abstract base class for QuickForm validation rules
  */
 require_once 'HTML/QuickForm/Rule.php';
 
@@ -51,11 +51,11 @@ class HTML_QuickForm_Rule_Callback extends HTML_QuickForm_Rule
 
    /**
     * Whether to use BC mode for specific rules
-    * 
+    *
     * Previous versions of QF passed element's name as a first parameter
     * to validation functions, but not to validation methods. This behaviour
     * is emulated if you are using 'function' as rule type when registering.
-    * 
+    *
     * @var array
     * @access private
     */
@@ -93,7 +93,7 @@ class HTML_QuickForm_Rule_Callback extends HTML_QuickForm_Rule
      * @param     string    $name       Name of rule
      * @param     string    $callback   Name of function or method
      * @param     string    $class      Name of class containing the method
-     * @param     bool      $BCMode     Backwards compatibility mode 
+     * @param     bool      $BCMode     Backwards compatibility mode
      * @access    public
      */
     function addData($name, $callback, $class = null, $BCMode = false)

--- a/HTML/QuickForm/Rule/Compare.php
+++ b/HTML/QuickForm/Rule/Compare.php
@@ -3,7 +3,7 @@
 
 /**
  * Rule to compare two form fields
- * 
+ *
  * PHP versions 4 and 5
  *
  * LICENSE: This source file is subject to version 3.01 of the PHP license
@@ -22,16 +22,16 @@
  */
 
 /**
- * Abstract base class for QuickForm validation rules 
+ * Abstract base class for QuickForm validation rules
  */
 require_once 'HTML/QuickForm/Rule.php';
 
 /**
  * Rule to compare two form fields
- * 
- * The most common usage for this is to ensure that the password 
+ *
+ * The most common usage for this is to ensure that the password
  * confirmation field matches the password field
- * 
+ *
  * @category    HTML
  * @package     HTML_QuickForm
  * @author      Alexey Borzov <avb@php.net>
@@ -59,7 +59,7 @@ class HTML_QuickForm_Rule_Compare extends HTML_QuickForm_Rule
 
    /**
     * Returns the operator to use for comparing the values
-    * 
+    *
     * @access private
     * @param  string     operator name
     * @return string     operator to use for validation
@@ -86,7 +86,7 @@ class HTML_QuickForm_Rule_Compare extends HTML_QuickForm_Rule
         } else {
             $compareFn = create_function('$a, $b', 'return strval($a) ' . $operator . ' strval($b);');
         }
-        
+
         return $compareFn($values[0], $values[1]);
     }
 

--- a/HTML/QuickForm/Rule/Range.php
+++ b/HTML/QuickForm/Rule/Range.php
@@ -3,7 +3,7 @@
 
 /**
  * Checks that the length of value is within range
- * 
+ *
  * PHP versions 4 and 5
  *
  * LICENSE: This source file is subject to version 3.01 of the PHP license
@@ -22,7 +22,7 @@
  */
 
 /**
- * Abstract base class for QuickForm validation rules 
+ * Abstract base class for QuickForm validation rules
  */
 require_once 'HTML/QuickForm/Rule.php';
 
@@ -59,13 +59,13 @@ class HTML_QuickForm_Rule_Range extends HTML_QuickForm_Rule
     function getValidationScript($options = null)
     {
         switch ($this->name) {
-            case 'minlength': 
+            case 'minlength':
                 $test = '{jsVar}.length < '.$options;
                 break;
-            case 'maxlength': 
+            case 'maxlength':
                 $test = '{jsVar}.length > '.$options;
                 break;
-            default: 
+            default:
                 $test = '({jsVar}.length < '.$options[0].' || {jsVar}.length > '.$options[1].')';
         }
         return array('', "{jsVar} != '' && {$test}");

--- a/HTML/QuickForm/Rule/Regex.php
+++ b/HTML/QuickForm/Rule/Regex.php
@@ -3,7 +3,7 @@
 
 /**
  * Validates values using regular expressions
- * 
+ *
  * PHP versions 4 and 5
  *
  * LICENSE: This source file is subject to version 3.01 of the PHP license
@@ -22,7 +22,7 @@
  */
 
 /**
- * Abstract base class for QuickForm validation rules 
+ * Abstract base class for QuickForm validation rules
  */
 require_once 'HTML/QuickForm/Rule.php';
 

--- a/HTML/QuickForm/Rule/Required.php
+++ b/HTML/QuickForm/Rule/Required.php
@@ -3,7 +3,7 @@
 
 /**
  * Required elements validation
- * 
+ *
  * PHP versions 4 and 5
  *
  * LICENSE: This source file is subject to version 3.01 of the PHP license
@@ -22,7 +22,7 @@
  */
 
 /**
- * Abstract base class for QuickForm validation rules 
+ * Abstract base class for QuickForm validation rules
  */
 require_once 'HTML/QuickForm/Rule.php';
 
@@ -53,8 +53,8 @@ class HTML_QuickForm_Rule_Required extends HTML_QuickForm_Rule
                 array_key_exists( 'name', $value ) &&
                 array_key_exists( 'tmp_name', $value );
             // hack to fix required issue with advcheckbox, but in general if any value is present then
-            // it should pass required check 
-            $return = false;    
+            // it should pass required check
+            $return = false;
             foreach ( $value as $k => $v ) {
                 // dont check type field. Safari3 Beta does not set this
                 if ( $fileType && $k == 'type' ) {

--- a/HTML/QuickForm/RuleRegistry.php
+++ b/HTML/QuickForm/RuleRegistry.php
@@ -3,7 +3,7 @@
 
 /**
  * Registers rule objects and uses them for validation
- * 
+ *
  * PHP versions 4 and 5
  *
  * LICENSE: This source file is subject to version 3.01 of the PHP license
@@ -48,7 +48,7 @@ class HTML_QuickForm_RuleRegistry
      * Returns a singleton of HTML_QuickForm_RuleRegistry
      *
      * Usually, only one RuleRegistry object is needed, this is the reason
-     * why it is recommended to use this method to get the validation object. 
+     * why it is recommended to use this method to get the validation object.
      *
      * @access    public
      * @static
@@ -135,7 +135,7 @@ class HTML_QuickForm_RuleRegistry
      * Performs validation on the given values
      *
      * @param     string   $ruleName        Name of the rule to be used
-     * @param     mixed    $values          Can be a scalar or an array of values 
+     * @param     mixed    $values          Can be a scalar or an array of values
      *                                      to be validated
      * @param     mixed    $options         Options used by the rule
      * @param     mixed    $multiple        Whether to validate an array of values altogether
@@ -163,7 +163,7 @@ class HTML_QuickForm_RuleRegistry
      * Returns the validation test in javascript code
      *
      * @param     array|HTML_QuickForm_element  Element(s) the rule applies to
-     * @param     string                        Element name, in case $element is 
+     * @param     string                        Element name, in case $element is
      *                                          not an array
      * @param     array                         Rule data
      * @access    public
@@ -187,21 +187,21 @@ class HTML_QuickForm_RuleRegistry
         $jsField = isset($ruleData['group'])? $ruleData['group']: $elementName;
         list ($jsPrefix, $jsCheck) = $rule->getValidationScript($ruleData['format']);
         if (!isset($ruleData['howmany'])) {
-            $js = $jsValue . "\n" . $jsPrefix . 
+            $js = $jsValue . "\n" . $jsPrefix .
                   "  if (" . str_replace('{jsVar}', 'value', $jsCheck) . " && !errFlag['{$jsField}']) {\n" .
                   "    errFlag['{$jsField}'] = true;\n" .
                   "    _qfMsg = _qfMsg + '\\n - {$ruleData['message']}';\n" .
                   $jsReset .
                   "  }\n";
         } else {
-            $js = $jsValue . "\n" . $jsPrefix . 
+            $js = $jsValue . "\n" . $jsPrefix .
                   "  var res = 0;\n" .
                   "  for (var i = 0; i < value.length; i++) {\n" .
                   "    if (!(" . str_replace('{jsVar}', 'value[i]', $jsCheck) . ")) {\n" .
                   "      res++;\n" .
                   "    }\n" .
-                  "  }\n" . 
-                  "  if (res < {$ruleData['howmany']} && !errFlag['{$jsField}']) {\n" . 
+                  "  }\n" .
+                  "  if (res < {$ruleData['howmany']} && !errFlag['{$jsField}']) {\n" .
                   "    errFlag['{$jsField}'] = true;\n" .
                   "    _qfMsg = _qfMsg + '\\n - {$ruleData['message']}';\n" .
                   $jsReset .
@@ -212,12 +212,12 @@ class HTML_QuickForm_RuleRegistry
 
 
    /**
-    * Returns JavaScript to get and to reset the element's value 
-    * 
+    * Returns JavaScript to get and to reset the element's value
+    *
     * @access private
     * @param  HTML_QuickForm_element    element being processed
     * @param  string                    element's name
-    * @param  bool                      whether to generate JavaScript to reset 
+    * @param  bool                      whether to generate JavaScript to reset
     *                                   the value
     * @param  integer                   value's index in the array (only used for
     *                                   multielement rules)
@@ -241,7 +241,7 @@ class HTML_QuickForm_RuleRegistry
                 "  var valueIdx = 0;\n" .
                 "  for (var i = 0; i < frm.elements.length; i++) {\n" .
                 "    var _element = frm.elements[i];\n" .
-                "    if (_element.name in _qfGroups['{$elementName}']) {\n" . 
+                "    if (_element.name in _qfGroups['{$elementName}']) {\n" .
                 "      switch (_element.type) {\n" .
                 "        case 'checkbox':\n" .
                 "        case 'radio':\n" .
@@ -275,7 +275,7 @@ class HTML_QuickForm_RuleRegistry
                 $tmp_reset =
                     "    for (var i = 0; i < frm.elements.length; i++) {\n" .
                     "      var _element = frm.elements[i];\n" .
-                    "      if (_element.name in _qfGroups['{$elementName}']) {\n" . 
+                    "      if (_element.name in _qfGroups['{$elementName}']) {\n" .
                     "        switch (_element.type) {\n" .
                     "          case 'checkbox':\n" .
                     "          case 'radio':\n" .
@@ -300,7 +300,7 @@ class HTML_QuickForm_RuleRegistry
                 $value =
                     "  value{$jsIndex} = new Array();\n" .
                     "  var valueIdx = 0;\n" .
-                    "  for (var i = 0; i < frm.elements['{$elementName}'].options.length; i++) {\n" . 
+                    "  for (var i = 0; i < frm.elements['{$elementName}'].options.length; i++) {\n" .
                     "    if (frm.elements['{$elementName}'].options[i].selected) {\n" .
                     "      value{$jsIndex}[valueIdx++] = frm.elements['{$elementName}'].options[i].value;\n" .
                     "    }\n" .
@@ -309,7 +309,7 @@ class HTML_QuickForm_RuleRegistry
                 $value = "  value{$jsIndex} = frm.elements['{$elementName}'].selectedIndex == -1? '': frm.elements['{$elementName}'].options[frm.elements['{$elementName}'].selectedIndex].value;\n";
             }
             if ($reset) {
-                $tmp_reset .= 
+                $tmp_reset .=
                     "    for (var i = 0; i < field.options.length; i++) {\n" .
                     "      field.options[i].selected = field.options[i].defaultSelected;\n" .
                     "    }\n";

--- a/HTML/QuickForm/advcheckbox.php
+++ b/HTML/QuickForm/advcheckbox.php
@@ -3,7 +3,7 @@
 
 /**
  * HTML class for an advanced checkbox type field
- * 
+ *
  * PHP versions 4 and 5
  *
  * LICENSE: This source file is subject to version 3.01 of the PHP license
@@ -33,15 +33,15 @@ require_once 'HTML/QuickForm/checkbox.php';
  * Basically this fixes a problem that HTML has had
  * where checkboxes can only pass a single value (the
  * value of the checkbox when checked).  A value for when
- * the checkbox is not checked cannot be passed, and 
+ * the checkbox is not checked cannot be passed, and
  * furthermore the checkbox variable doesn't even exist if
  * the checkbox was submitted unchecked.
  *
  * It works by prepending a hidden field with the same name and
  * another "unchecked" value to the checbox. If the checkbox is
  * checked, PHP overwrites the value of the hidden field with
- * its value. 
- * 
+ * its value.
+ *
  * @category    HTML
  * @package     HTML_QuickForm
  * @author      Jason Rust <jrust@php.net>
@@ -74,13 +74,13 @@ class HTML_QuickForm_advcheckbox extends HTML_QuickForm_checkbox
 
     /**
      * Class constructor
-     * 
+     *
      * @param     string    $elementName    (optional)Input field name attribute
-     * @param     string    $elementLabel   (optional)Input field label 
+     * @param     string    $elementLabel   (optional)Input field label
      * @param     string    $text           (optional)Text to put after the checkbox
-     * @param     mixed     $attributes     (optional)Either a typical HTML attribute string 
+     * @param     mixed     $attributes     (optional)Either a typical HTML attribute string
      *                                      or an associative array
-     * @param     mixed     $values         (optional)Values to pass if checked or not checked 
+     * @param     mixed     $values         (optional)Values to pass if checked or not checked
      *
      * @since     1.0
      * @access    public
@@ -91,7 +91,7 @@ class HTML_QuickForm_advcheckbox extends HTML_QuickForm_checkbox
         parent::__construct($elementName, $elementLabel, $text, $attributes);
         $this->setValues($values);
     } //end constructor
-    
+
     // }}}
     // {{{ getPrivateName()
 
@@ -148,7 +148,7 @@ class HTML_QuickForm_advcheckbox extends HTML_QuickForm_checkbox
             // give it default checkbox behavior
             $this->_values = array('', 1);
         } elseif (is_scalar($values)) {
-            // if it's string, then assume the value to 
+            // if it's string, then assume the value to
             // be passed is for when the element is checked
             $this->_values = array('', $values);
         } else {
@@ -163,7 +163,7 @@ class HTML_QuickForm_advcheckbox extends HTML_QuickForm_checkbox
 
    /**
     * Sets the element's value
-    * 
+    *
     * @param    mixed   Element's value
     * @access   public
     */
@@ -197,7 +197,7 @@ class HTML_QuickForm_advcheckbox extends HTML_QuickForm_checkbox
     /**
      * Returns the checkbox element in HTML
      * and the additional hidden element in HTML
-     * 
+     *
      * @access    public
      * @return    string
      */
@@ -207,14 +207,14 @@ class HTML_QuickForm_advcheckbox extends HTML_QuickForm_checkbox
             return parent::toHtml();
         } else {
             return '<input' . $this->_getAttrString(array(
-                        'type'  => 'hidden', 
-                        'name'  => $this->getName(), 
+                        'type'  => 'hidden',
+                        'name'  => $this->getName(),
                         'value' => $this->_values[0]
                    )) . ' />' . parent::toHtml();
-            
+
         }
     } //end func toHtml
-    
+
     // }}}
     // {{{ getFrozenHtml()
 

--- a/HTML/QuickForm/autocomplete.php
+++ b/HTML/QuickForm/autocomplete.php
@@ -3,7 +3,7 @@
 
 /**
  * HTML class for an autocomplete element
- * 
+ *
  * PHP versions 4 and 5
  *
  * LICENSE: This source file is subject to version 3.01 of the PHP license
@@ -23,20 +23,20 @@
 
 /**
  * HTML class for a text field
- */ 
+ */
 require_once 'HTML/QuickForm/text.php';
 
 /**
  * HTML class for an autocomplete element
- * 
+ *
  * Creates an HTML input text element that
  * at every keypressed javascript event checks in an array of options
  * if there's a match and autocompletes the text in case of match.
  *
  * For the JavaScript code thanks to Martin Honnen and Nicholas C. Zakas
  * See {@link http://www.faqts.com/knowledge_base/view.phtml/aid/13562} and
- * {@link http://www.sitepoint.com/article/1220} 
- * 
+ * {@link http://www.sitepoint.com/article/1220}
+ *
  * Example:
  * <code>
  * $autocomplete =& $form->addElement('autocomplete', 'fruit', 'Favourite fruit:');

--- a/HTML/QuickForm/button.php
+++ b/HTML/QuickForm/button.php
@@ -3,7 +3,7 @@
 
 /**
  * HTML class for an <input type="button" /> elements
- * 
+ *
  * PHP versions 4 and 5
  *
  * LICENSE: This source file is subject to version 3.01 of the PHP license
@@ -29,7 +29,7 @@ require_once 'HTML/QuickForm/input.php';
 
 /**
  * HTML class for an <input type="button" /> elements
- * 
+ *
  * @category    HTML
  * @package     HTML_QuickForm
  * @author      Adam Daniel <adaniel1@eesus.jnj.com>
@@ -43,10 +43,10 @@ class HTML_QuickForm_button extends HTML_QuickForm_input
 
     /**
      * Class constructor
-     * 
+     *
      * @param     string    $elementName    (optional)Input field name attribute
      * @param     string    $value          (optional)Input field value
-     * @param     mixed     $attributes     (optional)Either a typical HTML attribute string 
+     * @param     mixed     $attributes     (optional)Either a typical HTML attribute string
      *                                      or an associative array
      * @since     1.0
      * @access    public
@@ -59,13 +59,13 @@ class HTML_QuickForm_button extends HTML_QuickForm_input
         $this->setValue($value);
         $this->setType('button');
     } //end constructor
-    
+
     // }}}
     // {{{ freeze()
 
     /**
      * Freeze the element so that only its value is returned
-     * 
+     *
      * @access    public
      * @return    void
      */
@@ -75,6 +75,6 @@ class HTML_QuickForm_button extends HTML_QuickForm_input
     } //end func freeze
 
     // }}}
- 
+
 } //end class HTML_QuickForm_button
 ?>

--- a/HTML/QuickForm/checkbox.php
+++ b/HTML/QuickForm/checkbox.php
@@ -3,7 +3,7 @@
 
 /**
  * HTML class for a checkbox type field
- * 
+ *
  * PHP versions 4 and 5
  *
  * LICENSE: This source file is subject to version 3.01 of the PHP license
@@ -30,7 +30,7 @@ require_once 'HTML/QuickForm/input.php';
 
 /**
  * HTML class for a checkbox type field
- * 
+ *
  * @category    HTML
  * @package     HTML_QuickForm
  * @author      Adam Daniel <adaniel1@eesus.jnj.com>
@@ -56,11 +56,11 @@ class HTML_QuickForm_checkbox extends HTML_QuickForm_input
 
     /**
      * Class constructor
-     * 
+     *
      * @param     string    $elementName    (optional)Input field name attribute
      * @param     string    $elementLabel   (optional)Input field value
      * @param     string    $text           (optional)Checkbox display text
-     * @param     mixed     $attributes     (optional)Either a typical HTML attribute string 
+     * @param     mixed     $attributes     (optional)Either a typical HTML attribute string
      *                                      or an associative array
      * @since     1.0
      * @access    public
@@ -73,7 +73,7 @@ class HTML_QuickForm_checkbox extends HTML_QuickForm_input
             $attributes = array( 'id' => $elementName );
         } else {
             // set element id only if its not set
-            if ( !isset( $attributes['id'] ) ) { 
+            if ( !isset( $attributes['id'] ) ) {
                 $attributes['id'] = $elementName;
             }
         }
@@ -85,13 +85,13 @@ class HTML_QuickForm_checkbox extends HTML_QuickForm_input
         $this->updateAttributes(array('value'=>1));
         $this->_generateId();
     } //end constructor
-    
+
     // }}}
     // {{{ setChecked()
 
     /**
      * Sets whether a checkbox is checked
-     * 
+     *
      * @param     bool    $checked  Whether the field is checked or not
      * @since     1.0
      * @access    public
@@ -111,7 +111,7 @@ class HTML_QuickForm_checkbox extends HTML_QuickForm_input
 
     /**
      * Returns whether a checkbox is checked
-     * 
+     *
      * @since     1.0
      * @access    public
      * @return    bool
@@ -120,13 +120,13 @@ class HTML_QuickForm_checkbox extends HTML_QuickForm_input
     {
         return (bool)$this->getAttribute('checked');
     } //end func getChecked
-    
+
     // }}}
     // {{{ toHtml()
 
     /**
      * Returns the checkbox element in HTML
-     * 
+     *
      * @since     1.0
      * @access    public
      * @return    string
@@ -146,13 +146,13 @@ class HTML_QuickForm_checkbox extends HTML_QuickForm_input
         unset( $attributes['skipLabel'] );
         return HTML_QuickForm_input::toHtml() . $label;
     } //end func toHtml
-    
+
     // }}}
     // {{{ getFrozenHtml()
 
     /**
      * Returns the value of field without HTML tags
-     * 
+     *
      * @since     1.0
      * @access    public
      * @return    string
@@ -172,8 +172,8 @@ class HTML_QuickForm_checkbox extends HTML_QuickForm_input
 
     /**
      * Sets the checkbox text
-     * 
-     * @param     string    $text  
+     *
+     * @param     string    $text
      * @since     1.1
      * @access    public
      * @return    void
@@ -187,8 +187,8 @@ class HTML_QuickForm_checkbox extends HTML_QuickForm_input
     // {{{ getText()
 
     /**
-     * Returns the checkbox text 
-     * 
+     * Returns the checkbox text
+     *
      * @since     1.1
      * @access    public
      * @return    string
@@ -285,7 +285,7 @@ class HTML_QuickForm_checkbox extends HTML_QuickForm_input
         }
         return $this->_prepareValue($value, $assoc);
     }
-    
+
     // }}}
 } //end class HTML_QuickForm_checkbox
 ?>

--- a/HTML/QuickForm/date.php
+++ b/HTML/QuickForm/date.php
@@ -3,7 +3,7 @@
 
 /**
  * Class for a group of elements used to input dates (and times).
- * 
+ *
  * PHP versions 4 and 5
  *
  * LICENSE: This source file is subject to version 3.01 of the PHP license
@@ -32,10 +32,10 @@ require_once 'HTML/QuickForm/select.php';
 
 /**
  * Class for a group of elements used to input dates (and times).
- * 
+ *
  * Inspired by original 'date' element but reimplemented as a subclass
  * of HTML_QuickForm_group
- * 
+ *
  * @category    HTML
  * @package     HTML_QuickForm
  * @author      Alexey Borzov <avb@php.net>
@@ -48,7 +48,7 @@ class HTML_QuickForm_date extends HTML_QuickForm_group
 
    /**
     * Various options to control the element's display.
-    * 
+    *
     * @access   private
     * @var      array
     */
@@ -71,7 +71,7 @@ class HTML_QuickForm_date extends HTML_QuickForm_group
 
    /**
     * Locale array build from CRM_Utils_Date-provided names
-    * 
+    *
     * @access   private
     * @var      array
     */
@@ -82,12 +82,12 @@ class HTML_QuickForm_date extends HTML_QuickForm_group
 
    /**
     * Class constructor
-    * 
+    *
     * The following keys may appear in $options array:
     * - 'language': date language
     * - 'format': Format of the date, based on PHP's date() function.
     *   The following characters are currently recognised in format string:
-    *   <pre>  
+    *   <pre>
     *       D => Short names of days
     *       l => Long names of days
     *       d => Day numbers
@@ -119,11 +119,11 @@ class HTML_QuickForm_date extends HTML_QuickForm_group
     */
     function __construct($elementName = null, $elementLabel = null, $options = array(), $attributes = null)
     {
-        $this->_locale = array( 
-                               'weekdays_short'=> CRM_Utils_Date::getAbbrWeekdayNames(), 
-                               'weekdays_long' => CRM_Utils_Date::getFullWeekdayNames(), 
-                               'months_short'  => CRM_Utils_Date::getAbbrMonthNames(), 
-                               'months_long'   => CRM_Utils_Date::getFullMonthNames() 
+        $this->_locale = array(
+                               'weekdays_short'=> CRM_Utils_Date::getAbbrWeekdayNames(),
+                               'weekdays_long' => CRM_Utils_Date::getFullWeekdayNames(),
+                               'months_short'  => CRM_Utils_Date::getAbbrMonthNames(),
+                               'months_long'   => CRM_Utils_Date::getFullMonthNames()
                                );
         parent::__construct($elementName, $elementLabel, null, null, null, $attributes);
         $this->_persistantFreeze = true;
@@ -197,7 +197,7 @@ class HTML_QuickForm_date extends HTML_QuickForm_group
                     case 'Y':
                         $options = $this->_createOptionList(
                             $this->_options['minYear'],
-                            $this->_options['maxYear'], 
+                            $this->_options['maxYear'],
                             $this->_options['minYear'] > $this->_options['maxYear']? -1: 1
                         );
                         $emptyText = ts('-year-');
@@ -208,7 +208,7 @@ class HTML_QuickForm_date extends HTML_QuickForm_group
                             $this->_options['maxYear'],
                             $this->_options['minYear'] > $this->_options['maxYear']? -1: 1
                         );
-                        array_walk($options, create_function('&$v,$k','$v = substr($v,-2);')); 
+                        array_walk($options, create_function('&$v,$k','$v = substr($v,-2);'));
                         $emptyText = ts('-year-');
                         break;
                     case 'h':
@@ -250,7 +250,7 @@ class HTML_QuickForm_date extends HTML_QuickForm_group
                         $separator .= (' ' == $sign? '&nbsp;': $sign);
                         $loadSelect = false;
                 }
-    
+
                 if ($loadSelect) {
                     if (0 < count($this->_elements)) {
                         $this->_separator[] = $separator;
@@ -259,7 +259,7 @@ class HTML_QuickForm_date extends HTML_QuickForm_group
                     }
                     $separator = '';
                     // Should we add an empty option to the top of the select?
-                    if (!is_array($this->_options['addEmptyOption']) && $this->_options['addEmptyOption'] || 
+                    if (!is_array($this->_options['addEmptyOption']) && $this->_options['addEmptyOption'] ||
                         is_array($this->_options['addEmptyOption']) && !empty($this->_options['addEmptyOption'][$sign])) {
 
                         // Using '+' array operator to preserve the keys
@@ -271,12 +271,12 @@ class HTML_QuickForm_date extends HTML_QuickForm_group
                             $options = array($this->_options['emptyOptionValue'] => $text) + $options;
                         }
                     }
-                  
+
                     //modified autogenerated id for date select boxes.
                     $attribs = $this->getAttributes();
                     $elementName = $this->getName();
                     $attribs['id'] = $elementName.'['.$sign.']';
-                    
+
                     $this->_elements[] = new HTML_QuickForm_select($sign, null, $options, $attribs);
                 }
             }

--- a/HTML/QuickForm/element.php
+++ b/HTML/QuickForm/element.php
@@ -3,7 +3,7 @@
 
 /**
  * Base class for form elements
- * 
+ *
  * PHP versions 4 and 5
  *
  * LICENSE: This source file is subject to version 3.01 of the PHP license
@@ -30,7 +30,7 @@ require_once 'HTML/Common.php';
 
 /**
  * Base class for form elements
- * 
+ *
  * @category    HTML
  * @package     HTML_QuickForm
  * @author      Adam Daniel <adaniel1@eesus.jnj.com>
@@ -75,13 +75,13 @@ class HTML_QuickForm_element extends HTML_Common
      * @access    private
      */
     var $_persistantFreeze = false;
-    
+
     // }}}
     // {{{ constructor
-    
+
     /**
      * Class constructor
-     * 
+     *
      * @param    string     Name of the element
      * @param    mixed      Label(s) for the element
      * @param    mixed      Associative array of tag attributes or HTML attributes name="value" pairs
@@ -99,7 +99,7 @@ class HTML_QuickForm_element extends HTML_Common
             $this->setLabel($elementLabel);
         }
     } //end constructor
-    
+
     // }}}
     // {{{ apiVersion()
 
@@ -135,7 +135,7 @@ class HTML_QuickForm_element extends HTML_Common
 
     /**
      * Sets the input field name
-     * 
+     *
      * @param     string    $name   Input field name attribute
      * @since     1.0
      * @access    public
@@ -145,13 +145,13 @@ class HTML_QuickForm_element extends HTML_Common
     {
         // interface method
     } //end func setName
-    
+
     // }}}
     // {{{ getName()
 
     /**
      * Returns the element name
-     * 
+     *
      * @since     1.0
      * @access    public
      * @return    string
@@ -160,7 +160,7 @@ class HTML_QuickForm_element extends HTML_Common
     {
         // interface method
     } //end func getName
-    
+
     // }}}
     // {{{ setValue()
 
@@ -192,13 +192,13 @@ class HTML_QuickForm_element extends HTML_Common
         // interface
         return null;
     } // end func getValue
-    
+
     // }}}
     // {{{ freeze()
 
     /**
      * Freeze the element so that only its value is returned
-     * 
+     *
      * @access    public
      * @return    void
      */
@@ -227,7 +227,7 @@ class HTML_QuickForm_element extends HTML_Common
 
     /**
      * Returns the value of field without HTML tags
-     * 
+     *
      * @since     1.0
      * @access    public
      * @return    string
@@ -238,13 +238,13 @@ class HTML_QuickForm_element extends HTML_Common
         return (strlen($value)? htmlspecialchars($value): '&nbsp;') .
                $this->_getPersistantData();
     } //end func getFrozenHtml
-    
+
     // }}}
     // {{{ _getPersistantData()
 
    /**
     * Used by getFrozenHtml() to pass the element's value if _persistantFreeze is on
-    * 
+    *
     * @access private
     * @return string
     */
@@ -283,7 +283,7 @@ class HTML_QuickForm_element extends HTML_Common
     /**
      * Sets wether an element value should be kept in an hidden field
      * when the element is frozen or not
-     * 
+     *
      * @param     bool    $persistant   True if persistant value
      * @since     2.0
      * @access    public
@@ -299,7 +299,7 @@ class HTML_QuickForm_element extends HTML_Common
 
     /**
      * Sets display text for the element
-     * 
+     *
      * @param     string    $label  Display text for the element
      * @since     1.3
      * @access    public
@@ -315,7 +315,7 @@ class HTML_QuickForm_element extends HTML_Common
 
     /**
      * Returns display text for the element
-     * 
+     *
      * @since     1.3
      * @access    public
      * @return    string
@@ -330,7 +330,7 @@ class HTML_QuickForm_element extends HTML_Common
 
     /**
      * Tries to find the element value from the values array
-     * 
+     *
      * @since     2.7
      * @access    private
      * @return    mixed
@@ -345,7 +345,7 @@ class HTML_QuickForm_element extends HTML_Common
             return $values[$elementName];
         } elseif (strpos($elementName, '[')) {
             $myVar = "['" . str_replace(
-                         array('\\', '\'', ']', '['), array('\\\\', '\\\'', '', "']['"), 
+                         array('\\', '\'', ']', '['), array('\\\\', '\\\'', '', "']['"),
                          $elementName
                      ) . "']";
             return eval("return (isset(\$values$myVar)) ? \$values$myVar : null;");
@@ -407,7 +407,7 @@ class HTML_QuickForm_element extends HTML_Common
     * @param bool                       Whether an element is required
     * @param string                     An error message associated with an element
     * @access public
-    * @return void 
+    * @return void
     */
     function accept(&$renderer, $required=false, $error=null)
     {
@@ -419,12 +419,12 @@ class HTML_QuickForm_element extends HTML_Common
 
    /**
     * Automatically generates and assigns an 'id' attribute for the element.
-    * 
+    *
     * Currently used to ensure that labels work on radio buttons and
     * checkboxes. Per idea of Alexander Radivanovich.
     *
     * @access private
-    * @return void 
+    * @return void
     */
     function _generateId()
     {
@@ -454,7 +454,7 @@ class HTML_QuickForm_element extends HTML_Common
         }
         return $this->_prepareValue($value, $assoc);
     }
-    
+
     // }}}
     // {{{ _prepareValue()
 
@@ -479,7 +479,7 @@ class HTML_QuickForm_element extends HTML_Common
             } else {
                 $valueAry = array();
                 $myIndex  = "['" . str_replace(
-                                array('\\', '\'', ']', '['), array('\\\\', '\\\'', '', "']['"), 
+                                array('\\', '\'', ']', '['), array('\\\\', '\\\'', '', "']['"),
                                 $name
                             ) . "']";
                 eval("\$valueAry$myIndex = \$value;");
@@ -487,7 +487,7 @@ class HTML_QuickForm_element extends HTML_Common
             }
         }
     }
-    
+
     // }}}
 } // end class HTML_QuickForm_element
 ?>

--- a/HTML/QuickForm/header.php
+++ b/HTML/QuickForm/header.php
@@ -3,7 +3,7 @@
 
 /**
  * A pseudo-element used for adding headers to form
- * 
+ *
  * PHP versions 4 and 5
  *
  * LICENSE: This source file is subject to version 3.01 of the PHP license
@@ -23,11 +23,11 @@
 
 /**
  * HTML class for static data
- */ 
+ */
 require_once 'HTML/QuickForm/static.php';
 
 /**
- * A pseudo-element used for adding headers to form  
+ * A pseudo-element used for adding headers to form
  *
  * @category    HTML
  * @package     HTML_QuickForm
@@ -41,7 +41,7 @@ class HTML_QuickForm_header extends HTML_QuickForm_static
 
    /**
     * Class constructor
-    * 
+    *
     * @param string $elementName    Header name
     * @param string $text           Header text
     * @access public
@@ -61,7 +61,7 @@ class HTML_QuickForm_header extends HTML_QuickForm_static
     *
     * @param HTML_QuickForm_Renderer    renderer object
     * @access public
-    * @return void 
+    * @return void
     */
     function accept(&$renderer)
     {

--- a/HTML/QuickForm/hiddenselect.php
+++ b/HTML/QuickForm/hiddenselect.php
@@ -3,7 +3,7 @@
 
 /**
  * Hidden select pseudo-element
- * 
+ *
  * PHP versions 4 and 5
  *
  * LICENSE: This source file is subject to version 3.01 of the PHP license
@@ -44,10 +44,10 @@ require_once 'HTML/QuickForm/select.php';
 class HTML_QuickForm_hiddenselect extends HTML_QuickForm_select
 {
     // {{{ constructor
-        
+
     /**
      * Class constructor
-     * 
+     *
      * @param     string    Select name attribute
      * @param     mixed     Label(s) for the select (not used)
      * @param     mixed     Data to be used to populate options
@@ -65,7 +65,7 @@ class HTML_QuickForm_hiddenselect extends HTML_QuickForm_select
             $this->load($options);
         }
     } //end constructor
-    
+
     // }}}
     // {{{ toHtml()
 
@@ -75,7 +75,7 @@ class HTML_QuickForm_hiddenselect extends HTML_QuickForm_select
      * @since     1.0
      * @access    public
      * @return    string
-     * @throws    
+     * @throws
      */
     function toHtml()
     {
@@ -101,12 +101,12 @@ class HTML_QuickForm_hiddenselect extends HTML_QuickForm_select
 
         return $strHtml;
     } //end func toHtml
-    
+
     // }}}
     // {{{ accept()
 
    /**
-    * This is essentially a hidden element and should be rendered as one  
+    * This is essentially a hidden element and should be rendered as one
     */
     function accept(&$renderer)
     {

--- a/HTML/QuickForm/hierselect.php
+++ b/HTML/QuickForm/hierselect.php
@@ -35,7 +35,7 @@ require_once('HTML/QuickForm/select.php');
  * @access       public
  */
 class HTML_QuickForm_hierselect extends HTML_QuickForm_group
-{   
+{
     // {{{ properties
 
     /**
@@ -58,7 +58,7 @@ class HTML_QuickForm_hierselect extends HTML_QuickForm_group
      * $select2[2][0] = 'Pantheist';
      * $select2[2][1] = 'Skepticism';
      *
-     * // If only need two selects 
+     * // If only need two selects
      * //     - and using the depracated functions
      * $sel =& $form->addElement('hierselect', 'cds', 'Choose CD:');
      * $sel->setMainOptions($select1);
@@ -76,12 +76,12 @@ class HTML_QuickForm_hierselect extends HTML_QuickForm_group
      * // You can now use
      * $sel =& $form->addElement('hierselect', 'cds', 'Choose CD:');
      * $sel->setOptions(array($select1, $select2, $select3));
-     * 
+     *
      * @var       array
      * @access    private
      */
     var $_options = array();
-    
+
     /**
      * Number of select elements on this group
      *
@@ -97,7 +97,7 @@ class HTML_QuickForm_hierselect extends HTML_QuickForm_group
      * @access    private
      */
     var $_js = '';
-    
+
     /**
     * The javascript array name
     */
@@ -108,10 +108,10 @@ class HTML_QuickForm_hierselect extends HTML_QuickForm_group
 
     /**
      * Class constructor
-     * 
+     *
      * @param     string    $elementName    (optional)Input field name attribute
      * @param     string    $elementLabel   (optional)Input field label in form
-     * @param     mixed     $attributes     (optional)Either a typical HTML attribute string 
+     * @param     mixed     $attributes     (optional)Either a typical HTML attribute string
      *                                      or an associative array. Date format is passed along the attributes.
      * @param     mixed     $separator      (optional)Use a string for one separator,
      *                                      use an array to alternate the separators.
@@ -157,14 +157,14 @@ class HTML_QuickForm_hierselect extends HTML_QuickForm_group
                 $this->_nbElements++;
             }
         }
-        
+
         $this->_setOptions();
         $this->_setJS();
     } // end func setMainOptions
 
     // }}}
     // {{{ setMainOptions()
-    
+
     /**
      * Sets the options for the first select element. Deprecated. setOptions() should be used.
      *
@@ -182,10 +182,10 @@ class HTML_QuickForm_hierselect extends HTML_QuickForm_group
             $this->_createElements();
         }
     } // end func setMainOptions
-    
+
     // }}}
     // {{{ setSecOptions()
-    
+
     /**
      * Sets the options for the second select element. Deprecated. setOptions() should be used.
      * The main _options array is initialized and the _setOptions function is called.
@@ -211,14 +211,14 @@ class HTML_QuickForm_hierselect extends HTML_QuickForm_group
                 $this->_nbElements++;
             }
         }
-        
+
         $this->_setOptions();
         $this->_setJS();
     } // end func setSecOptions
-    
+
     // }}}
     // {{{ _setOptions()
-    
+
     /**
      * Sets the options for each select element
      *
@@ -242,13 +242,13 @@ class HTML_QuickForm_hierselect extends HTML_QuickForm_group
             }
         }
     } // end func _setOptions
-    
+
     // }}}
     // {{{ setValue()
 
     /**
      * Sets values for group's elements
-     * 
+     *
      * @param     array     $value    An array of 2 or more values, for the first,
      *                                the second, the third etc. select
      *
@@ -261,13 +261,13 @@ class HTML_QuickForm_hierselect extends HTML_QuickForm_group
         parent::setValue($value);
         $this->_setOptions();
     } // end func setValue
-    
+
     // }}}
     // {{{ _createElements()
 
     /**
      * Creates all the elements for the group
-     * 
+     *
      * @access    private
      * @return    void
      */
@@ -291,7 +291,7 @@ class HTML_QuickForm_hierselect extends HTML_QuickForm_group
 
     // }}}
     // {{{ _setJS()
-    
+
     /**
      * Set the JavaScript for each select element (excluding de main one).
      *
@@ -313,10 +313,10 @@ class HTML_QuickForm_hierselect extends HTML_QuickForm_group
             $this->_jsArrayName = $jsArrayName;
         }
     } // end func _setJS
-    
+
     // }}}
     // {{{ _setJSArray()
-    
+
     /**
      * Recursively builds the JavaScript array defining the options that a select
      * element can have.
@@ -337,13 +337,13 @@ class HTML_QuickForm_hierselect extends HTML_QuickForm_group
             // For a hierselect containing 3 elements:
             //      if option 1 has been selected for the 1st element
             //      and option 3 has been selected for the 2nd element,
-            //      then the javascript array containing the values to load 
+            //      then the javascript array containing the values to load
             //      on the 3rd element will have the following name:   grpName_1_3
             $name  = ($optValue === '') ? $grpName : $grpName.'_'.$optValue;
             foreach($options AS $k => $v) {
                 $this->_setJSArray($name, $v, $js, $k);
             }
-            
+
             // if $js !== '' add it to the JavaScript
 
             if ( $js !== '' ) {
@@ -371,7 +371,7 @@ class HTML_QuickForm_hierselect extends HTML_QuickForm_group
 
     /**
      * Returns Html for the group
-     * 
+     *
      * @access      public
      * @return      string
      */
@@ -390,7 +390,7 @@ class HTML_QuickForm_hierselect extends HTML_QuickForm_group
                     array('onChange' => 'swapOptions(this.form, \''.$this->getName().'\', '.$keys[$i].', '.$nbElements.', \''.$this->_jsArrayName.'\');')
                 );
             }
-            
+
             // create the js function to call
             if (!defined('HTML_QUICKFORM_HIERSELECT_EXISTS')) {
                 $this->_js .= "function swapOptions(frm, grpName, eleIndex, nbElements, arName)\n"
@@ -417,7 +417,7 @@ class HTML_QuickForm_hierselect extends HTML_QuickForm_group
                              ."        if (!ctl) {\n"
                              ."            ctl = frm[grpName+'['+ n +'][]'];\n"
                              ."        }\n"
-                             ."        ctl.style.display = 'inline';\n" 
+                             ."        ctl.style.display = 'inline';\n"
                              ."        for (var i in the_array) {\n"
                              ."            opt = new Option(the_array[i], i, false, false);\n"
                              ."            ctl.options[j++] = opt;\n"
@@ -461,7 +461,7 @@ class HTML_QuickForm_hierselect extends HTML_QuickForm_group
     * @param bool       Whether a group is required
     * @param string     An error message associated with a group
     * @access public
-    * @return void 
+    * @return void
     */
     function accept(&$renderer, $required = false, $error = null)
     {
@@ -482,6 +482,6 @@ class HTML_QuickForm_hierselect extends HTML_QuickForm_group
         }
     } // end func onQuickFormEvent
 
-    // }}}    
+    // }}}
 } // end class HTML_QuickForm_hierselect
 ?>

--- a/HTML/QuickForm/html.php
+++ b/HTML/QuickForm/html.php
@@ -3,7 +3,7 @@
 
 /**
  * A pseudo-element used for adding raw HTML to form
- * 
+ *
  * PHP versions 4 and 5
  *
  * LICENSE: This source file is subject to version 3.01 of the PHP license
@@ -28,7 +28,7 @@ require_once 'HTML/QuickForm/static.php';
 
 /**
  * A pseudo-element used for adding raw HTML to form
- * 
+ *
  * Intended for use with the default renderer only, template-based
  * ones may (and probably will) completely ignore this
  *
@@ -45,7 +45,7 @@ class HTML_QuickForm_html extends HTML_QuickForm_static
 
    /**
     * Class constructor
-    * 
+    *
     * @param string $text   raw HTML to add
     * @access public
     * @return void
@@ -64,7 +64,7 @@ class HTML_QuickForm_html extends HTML_QuickForm_static
     *
     * @param HTML_QuickForm_Renderer    renderer object (only works with Default renderer!)
     * @access public
-    * @return void 
+    * @return void
     */
     function accept(&$renderer)
     {

--- a/HTML/QuickForm/image.php
+++ b/HTML/QuickForm/image.php
@@ -3,7 +3,7 @@
 
 /**
  * HTML class for an <input type="image" /> element
- * 
+ *
  * PHP versions 4 and 5
  *
  * LICENSE: This source file is subject to version 3.01 of the PHP license
@@ -29,7 +29,7 @@ require_once 'HTML/QuickForm/input.php';
 
 /**
  * HTML class for an <input type="image" /> element
- * 
+ *
  * @category    HTML
  * @package     HTML_QuickForm
  * @author      Adam Daniel <adaniel1@eesus.jnj.com>
@@ -43,10 +43,10 @@ class HTML_QuickForm_image extends HTML_QuickForm_input
 
     /**
      * Class constructor
-     * 
+     *
      * @param     string    $elementName    (optional)Element name attribute
      * @param     string    $src            (optional)Image source
-     * @param     mixed     $attributes     (optional)Either a typical HTML attribute string 
+     * @param     mixed     $attributes     (optional)Either a typical HTML attribute string
      *                                      or an associative array
      * @since     1.0
      * @access    public
@@ -64,7 +64,7 @@ class HTML_QuickForm_image extends HTML_QuickForm_input
 
     /**
      * Sets source for image element
-     * 
+     *
      * @param     string    $src  source for image element
      * @since     1.0
      * @access    public
@@ -80,7 +80,7 @@ class HTML_QuickForm_image extends HTML_QuickForm_input
 
     /**
      * Sets border size for image element
-     * 
+     *
      * @param     string    $border  border for image element
      * @since     1.0
      * @access    public
@@ -96,7 +96,7 @@ class HTML_QuickForm_image extends HTML_QuickForm_input
 
     /**
      * Sets alignment for image element
-     * 
+     *
      * @param     string    $align  alignment for image element
      * @since     1.0
      * @access    public
@@ -112,7 +112,7 @@ class HTML_QuickForm_image extends HTML_QuickForm_input
 
     /**
      * Freeze the element so that only its value is returned
-     * 
+     *
      * @access    public
      * @return    void
      */

--- a/HTML/QuickForm/input.php
+++ b/HTML/QuickForm/input.php
@@ -3,7 +3,7 @@
 
 /**
  * Base class for <input /> form elements
- * 
+ *
  * PHP versions 4 and 5
  *
  * LICENSE: This source file is subject to version 3.01 of the PHP license
@@ -24,12 +24,12 @@
 
 /**
  * Base class for form elements
- */ 
+ */
 require_once 'HTML/QuickForm/element.php';
 
 /**
  * Base class for <input /> form elements
- * 
+ *
  * @category    HTML
  * @package     HTML_QuickForm
  * @author      Adam Daniel <adaniel1@eesus.jnj.com>
@@ -44,7 +44,7 @@ class HTML_QuickForm_input extends HTML_QuickForm_element
 
     /**
      * Class constructor
-     * 
+     *
      * @param    string     Input field name attribute
      * @param    mixed      Label(s) for the input field
      * @param    mixed      Either a typical HTML attribute string or an associative array
@@ -73,13 +73,13 @@ class HTML_QuickForm_input extends HTML_QuickForm_element
         $this->_type = $type;
         $this->updateAttributes(array('type'=>$type));
     } // end func setType
-    
+
     // }}}
     // {{{ setName()
 
     /**
      * Sets the input field name
-     * 
+     *
      * @param     string    $name   Input field name attribute
      * @since     1.0
      * @access    public
@@ -89,13 +89,13 @@ class HTML_QuickForm_input extends HTML_QuickForm_element
     {
         $this->updateAttributes(array('name'=>$name));
     } //end func setName
-    
+
     // }}}
     // {{{ getName()
 
     /**
      * Returns the element name
-     * 
+     *
      * @since     1.0
      * @access    public
      * @return    string
@@ -104,7 +104,7 @@ class HTML_QuickForm_input extends HTML_QuickForm_element
     {
         return $this->getAttribute('name');
     } //end func getName
-    
+
     // }}}
     // {{{ setValue()
 
@@ -135,13 +135,13 @@ class HTML_QuickForm_input extends HTML_QuickForm_element
     {
         return $this->getAttribute('value');
     } // end func getValue
-    
+
     // }}}
     // {{{ toHtml()
 
     /**
      * Returns the input field in HTML
-     * 
+     *
      * @since     1.0
      * @access    public
      * @return    string
@@ -167,7 +167,7 @@ class HTML_QuickForm_input extends HTML_QuickForm_element
      * @since     1.0
      * @access    public
      * @return    void
-     * @throws    
+     * @throws
      */
     function onQuickFormEvent($event, $arg, &$caller)
     {
@@ -203,7 +203,7 @@ class HTML_QuickForm_input extends HTML_QuickForm_element
             return parent::exportValue($submitValues, $assoc);
         }
     }
-    
+
     // }}}
 } // end class HTML_QuickForm_element
 ?>

--- a/HTML/QuickForm/link.php
+++ b/HTML/QuickForm/link.php
@@ -3,7 +3,7 @@
 
 /**
  * HTML class for a link type field
- * 
+ *
  * PHP versions 4 and 5
  *
  * LICENSE: This source file is subject to version 3.01 of the PHP license
@@ -24,12 +24,12 @@
 
 /**
  * HTML class for static data
- */ 
+ */
 require_once 'HTML/QuickForm/static.php';
 
 /**
  * HTML class for a link type field
- * 
+ *
  * @category    HTML
  * @package     HTML_QuickForm
  * @author      Adam Daniel <adaniel1@eesus.jnj.com>
@@ -51,19 +51,19 @@ class HTML_QuickForm_link extends HTML_QuickForm_static
 
     // }}}
     // {{{ constructor
-    
+
     /**
      * Class constructor
-     * 
+     *
      * @param     string    $elementLabel   (optional)Link label
      * @param     string    $href           (optional)Link href
      * @param     string    $text           (optional)Link display text
-     * @param     mixed     $attributes     (optional)Either a typical HTML attribute string 
+     * @param     mixed     $attributes     (optional)Either a typical HTML attribute string
      *                                      or an associative array
      * @since     1.0
      * @access    public
      * @return    void
-     * @throws    
+     * @throws
      */
     function __construct($elementName=null, $elementLabel=null, $href=null, $text=null, $attributes=null)
     {
@@ -73,34 +73,34 @@ class HTML_QuickForm_link extends HTML_QuickForm_static
         $this->setHref($href);
         $this->_text = $text;
     } //end constructor
-    
+
     // }}}
     // {{{ setName()
 
     /**
      * Sets the input field name
-     * 
+     *
      * @param     string    $name   Input field name attribute
      * @since     1.0
      * @access    public
      * @return    void
-     * @throws    
+     * @throws
      */
     function setName($name)
     {
         $this->updateAttributes(array('name'=>$name));
     } //end func setName
-    
+
     // }}}
     // {{{ getName()
 
     /**
      * Returns the element name
-     * 
+     *
      * @since     1.0
      * @access    public
      * @return    string
-     * @throws    
+     * @throws
      */
     function getName()
     {
@@ -112,18 +112,18 @@ class HTML_QuickForm_link extends HTML_QuickForm_static
 
     /**
      * Sets value for textarea element
-     * 
+     *
      * @param     string    $value  Value for password element
      * @since     1.0
      * @access    public
      * @return    void
-     * @throws    
+     * @throws
      */
     function setValue($value)
     {
         return;
     } //end func setValue
-    
+
     // }}}
     // {{{ getValue()
 
@@ -133,14 +133,14 @@ class HTML_QuickForm_link extends HTML_QuickForm_static
      * @since     1.0
      * @access    public
      * @return    void
-     * @throws    
+     * @throws
      */
     function getValue()
     {
         return;
     } // end func getValue
 
-    
+
     // }}}
     // {{{ setHref()
 
@@ -151,7 +151,7 @@ class HTML_QuickForm_link extends HTML_QuickForm_static
      * @since     1.0
      * @access    public
      * @return    void
-     * @throws    
+     * @throws
      */
     function setHref($href)
     {
@@ -163,11 +163,11 @@ class HTML_QuickForm_link extends HTML_QuickForm_static
 
     /**
      * Returns the textarea element in HTML
-     * 
+     *
      * @since     1.0
      * @access    public
      * @return    string
-     * @throws    
+     * @throws
      */
     function toHtml()
     {
@@ -177,17 +177,17 @@ class HTML_QuickForm_link extends HTML_QuickForm_static
         $html .= "</a>";
         return $html;
     } //end func toHtml
-    
+
     // }}}
     // {{{ getFrozenHtml()
 
     /**
      * Returns the value of field without HTML tags (in this case, value is changed to a mask)
-     * 
+     *
      * @since     1.0
      * @access    public
      * @return    string
-     * @throws    
+     * @throws
      */
     function getFrozenHtml()
     {

--- a/HTML/QuickForm/password.php
+++ b/HTML/QuickForm/password.php
@@ -3,7 +3,7 @@
 
 /**
  * HTML class for a password type field
- * 
+ *
  * PHP versions 4 and 5
  *
  * LICENSE: This source file is subject to version 3.01 of the PHP license
@@ -29,7 +29,7 @@ require_once 'HTML/QuickForm/input.php';
 
 /**
  * HTML class for a password type field
- * 
+ *
  * @category    HTML
  * @package     HTML_QuickForm
  * @author      Adam Daniel <adaniel1@eesus.jnj.com>
@@ -43,28 +43,28 @@ class HTML_QuickForm_password extends HTML_QuickForm_input
 
     /**
      * Class constructor
-     * 
+     *
      * @param     string    $elementName    (optional)Input field name attribute
      * @param     string    $elementLabel   (optional)Input field label
-     * @param     mixed     $attributes     (optional)Either a typical HTML attribute string 
+     * @param     mixed     $attributes     (optional)Either a typical HTML attribute string
      *                                      or an associative array
      * @since     1.0
      * @access    public
      * @return    void
-     * @throws    
+     * @throws
      */
     function __construct($elementName=null, $elementLabel=null, $attributes=null)
     {
         parent::__construct($elementName, $elementLabel, $attributes);
         $this->setType('password');
     } //end constructor
-    
+
     // }}}
     // {{{ setSize()
 
     /**
      * Sets size of password element
-     * 
+     *
      * @param     string    $size  Size of password field
      * @since     1.0
      * @access    public
@@ -80,7 +80,7 @@ class HTML_QuickForm_password extends HTML_QuickForm_input
 
     /**
      * Sets maxlength of password element
-     * 
+     *
      * @param     string    $maxlength  Maximum length of password field
      * @since     1.0
      * @access    public
@@ -90,17 +90,17 @@ class HTML_QuickForm_password extends HTML_QuickForm_input
     {
         $this->updateAttributes(array('maxlength'=>$maxlength));
     } //end func setMaxlength
-        
+
     // }}}
     // {{{ getFrozenHtml()
 
     /**
      * Returns the value of field without HTML tags (in this case, value is changed to a mask)
-     * 
+     *
      * @since     1.0
      * @access    public
      * @return    string
-     * @throws    
+     * @throws
      */
     function getFrozenHtml()
     {

--- a/HTML/QuickForm/reset.php
+++ b/HTML/QuickForm/reset.php
@@ -3,7 +3,7 @@
 
 /**
  * HTML class for a reset type element
- * 
+ *
  * PHP versions 4 and 5
  *
  * LICENSE: This source file is subject to version 3.01 of the PHP license
@@ -29,7 +29,7 @@ require_once 'HTML/QuickForm/input.php';
 
 /**
  * HTML class for a reset type element
- * 
+ *
  * @category    HTML
  * @package     HTML_QuickForm
  * @author      Adam Daniel <adaniel1@eesus.jnj.com>
@@ -40,13 +40,13 @@ require_once 'HTML/QuickForm/input.php';
 class HTML_QuickForm_reset extends HTML_QuickForm_input
 {
     // {{{ constructor
-    
+
     /**
      * Class constructor
-     * 
+     *
      * @param     string    $elementName    (optional)Input field name attribute
      * @param     string    $value          (optional)Input field value
-     * @param     mixed     $attributes     (optional)Either a typical HTML attribute string 
+     * @param     mixed     $attributes     (optional)Either a typical HTML attribute string
      *                                      or an associative array
      * @since     1.0
      * @access    public
@@ -64,7 +64,7 @@ class HTML_QuickForm_reset extends HTML_QuickForm_input
 
     /**
      * Freeze the element so that only its value is returned
-     * 
+     *
      * @access    public
      * @return    void
      */

--- a/HTML/QuickForm/select.php
+++ b/HTML/QuickForm/select.php
@@ -3,7 +3,7 @@
 
 /**
  * Class to dynamically create an HTML SELECT
- * 
+ *
  * PHP versions 4 and 5
  *
  * LICENSE: This source file is subject to version 3.01 of the PHP license
@@ -25,7 +25,7 @@
 
 /**
  * Base class for form elements
- */ 
+ */
 require_once 'HTML/QuickForm/element.php';
 
 /**
@@ -40,7 +40,7 @@ require_once 'HTML/QuickForm/element.php';
  * @since       1.0
  */
 class HTML_QuickForm_select extends HTML_QuickForm_element {
-    
+
     // {{{ properties
 
     /**
@@ -51,10 +51,10 @@ class HTML_QuickForm_select extends HTML_QuickForm_element {
      * @access    private
      */
     var $_options = array();
-    
+
     /**
      * Default values of the SELECT
-     * 
+     *
      * @var       string
      * @since     1.0
      * @access    private
@@ -63,10 +63,10 @@ class HTML_QuickForm_select extends HTML_QuickForm_element {
 
     // }}}
     // {{{ constructor
-        
+
     /**
      * Class constructor
-     * 
+     *
      * @param     string    Select name attribute
      * @param     mixed     Label(s) for the select
      * @param     mixed     Data to be used to populate options
@@ -84,13 +84,13 @@ class HTML_QuickForm_select extends HTML_QuickForm_element {
             $this->load($options);
         }
     } //end constructor
-    
+
     // }}}
     // {{{ apiVersion()
 
     /**
-     * Returns the current API version 
-     * 
+     * Returns the current API version
+     *
      * @since     1.0
      * @access    public
      * @return    double
@@ -105,7 +105,7 @@ class HTML_QuickForm_select extends HTML_QuickForm_element {
 
     /**
      * Sets the default values of the select box
-     * 
+     *
      * @param     mixed    $values  Array or comma delimited string of selected values
      * @since     1.0
      * @access    public
@@ -122,13 +122,13 @@ class HTML_QuickForm_select extends HTML_QuickForm_element {
             $this->_values = array($values);
         }
     } //end func setSelected
-    
+
     // }}}
     // {{{ getSelected()
 
     /**
      * Returns an array of the selected values
-     * 
+     *
      * @since     1.0
      * @access    public
      * @return    array of selected values
@@ -143,7 +143,7 @@ class HTML_QuickForm_select extends HTML_QuickForm_element {
 
     /**
      * Sets the input field name
-     * 
+     *
      * @param     string    $name   Input field name attribute
      * @since     1.0
      * @access    public
@@ -153,13 +153,13 @@ class HTML_QuickForm_select extends HTML_QuickForm_element {
     {
         $this->updateAttributes(array('name' => $name));
     } //end func setName
-    
+
     // }}}
     // {{{ getName()
 
     /**
      * Returns the element name
-     * 
+     *
      * @since     1.0
      * @access    public
      * @return    string
@@ -174,7 +174,7 @@ class HTML_QuickForm_select extends HTML_QuickForm_element {
 
     /**
      * Returns the element name (possibly with brackets appended)
-     * 
+     *
      * @since     1.0
      * @access    public
      * @return    string
@@ -209,7 +209,7 @@ class HTML_QuickForm_select extends HTML_QuickForm_element {
 
     /**
      * Returns an array of the selected values
-     * 
+     *
      * @since     1.0
      * @access    public
      * @return    array of selected values
@@ -224,7 +224,7 @@ class HTML_QuickForm_select extends HTML_QuickForm_element {
 
     /**
      * Sets the select field size, only applies to 'multiple' selects
-     * 
+     *
      * @param     int    $size  Size of select  field
      * @since     1.0
      * @access    public
@@ -234,13 +234,13 @@ class HTML_QuickForm_select extends HTML_QuickForm_element {
     {
         $this->updateAttributes(array('size' => $size));
     } //end func setSize
-    
+
     // }}}
     // {{{ getSize()
 
     /**
      * Returns the select field size
-     * 
+     *
      * @since     1.0
      * @access    public
      * @return    int
@@ -255,7 +255,7 @@ class HTML_QuickForm_select extends HTML_QuickForm_element {
 
     /**
      * Sets the select mutiple attribute
-     * 
+     *
      * @param     bool    $multiple  Whether the select supports multi-selections
      * @since     1.2
      * @access    public
@@ -269,13 +269,13 @@ class HTML_QuickForm_select extends HTML_QuickForm_element {
             $this->removeAttribute('multiple');
         }
     } //end func setMultiple
-    
+
     // }}}
     // {{{ getMultiple()
 
     /**
      * Returns the select mutiple attribute
-     * 
+     *
      * @since     1.2
      * @access    public
      * @return    bool    true if multiple select, false otherwise
@@ -293,7 +293,7 @@ class HTML_QuickForm_select extends HTML_QuickForm_element {
      *
      * @param     string    $text       Display text for the OPTION
      * @param     string    $value      Value for the OPTION
-     * @param     mixed     $attributes Either a typical HTML attribute string 
+     * @param     mixed     $attributes Either a typical HTML attribute string
      *                                  or an associative array
      * @since     1.0
      * @access    public
@@ -318,13 +318,13 @@ class HTML_QuickForm_select extends HTML_QuickForm_element {
         }
         $this->_options[] = array('text' => $text, 'attr' => $attributes);
     } // end func addOption
-    
+
     // }}}
     // {{{ loadArray()
 
     /**
      * Loads the options from an associative array
-     * 
+     *
      * @param     array    $arr     Associative array of options
      * @param     mixed    $values  (optional) Array or comma delimited string of selected values
      * @since     1.0
@@ -352,12 +352,12 @@ class HTML_QuickForm_select extends HTML_QuickForm_element {
 
     /**
      * Loads the options from DB_result object
-     * 
+     *
      * If no column names are specified the first two columns of the result are
      * used as the text and value columns respectively
-     * @param     object    $result     DB_result object 
-     * @param     string    $textCol    (optional) Name of column to display as the OPTION text 
-     * @param     string    $valueCol   (optional) Name of column to use as the OPTION value 
+     * @param     object    $result     DB_result object
+     * @param     string    $textCol    (optional) Name of column to display as the OPTION text
+     * @param     string    $valueCol   (optional) Name of column to use as the OPTION value
      * @param     mixed     $values     (optional) Array or comma delimited string of selected values
      * @since     1.0
      * @access    public
@@ -382,17 +382,17 @@ class HTML_QuickForm_select extends HTML_QuickForm_element {
         }
         return true;
     } // end func loadDbResult
-    
+
     // }}}
     // {{{ loadQuery()
 
     /**
      * Queries a database and loads the options from the results
      *
-     * @param     mixed     $conn       Either an existing DB connection or a valid dsn 
+     * @param     mixed     $conn       Either an existing DB connection or a valid dsn
      * @param     string    $sql        SQL query string
-     * @param     string    $textCol    (optional) Name of column to display as the OPTION text 
-     * @param     string    $valueCol   (optional) Name of column to use as the OPTION value 
+     * @param     string    $textCol    (optional) Name of column to display as the OPTION text
+     * @param     string    $valueCol   (optional) Name of column to use as the OPTION value
      * @param     mixed     $values     (optional) Array or comma delimited string of selected values
      * @since     1.1
      * @access    public
@@ -434,7 +434,7 @@ class HTML_QuickForm_select extends HTML_QuickForm_element {
      * first are optional and only mean something depending on the type of the first argument.
      * If the first argument is an array then all arguments are passed in order to loadArray.
      * If the first argument is a db_result then all arguments are passed in order to loadDbResult.
-     * If the first argument is a string or a DB connection then all arguments are 
+     * If the first argument is a string or a DB connection then all arguments are
      * passed in order to loadQuery.
      * @param     mixed     $options     Options source currently supports assoc array or DB_result
      * @param     mixed     $param1     (optional) See function detail
@@ -460,7 +460,7 @@ class HTML_QuickForm_select extends HTML_QuickForm_element {
                 break;
         }
     } // end func load
-    
+
     // }}}
     // {{{ toHtml()
 
@@ -505,13 +505,13 @@ class HTML_QuickForm_select extends HTML_QuickForm_element {
             return $strHtml . $tabs . '</select>';
         }
     } //end func toHtml
-    
+
     // }}}
     // {{{ getFrozenHtml()
 
     /**
      * Returns the value of field without HTML tags
-     * 
+     *
      * @since     1.0
      * @access    public
      * @return    string
@@ -583,7 +583,7 @@ class HTML_QuickForm_select extends HTML_QuickForm_element {
             //if value is null make it empty array, checked most of
             // the stuff, value is null for advselect
             // fix for CRM-1431 - kurund
-            if (is_null($value)) { 
+            if (is_null($value)) {
                 $cleanValue = array();
             } else {
                 $cleanValue = $value;
@@ -597,7 +597,7 @@ class HTML_QuickForm_select extends HTML_QuickForm_element {
             return $this->_prepareValue($cleanValue, $assoc);
         }
     }
-    
+
     // }}}
     // {{{ onQuickFormEvent()
 

--- a/HTML/QuickForm/submit.php
+++ b/HTML/QuickForm/submit.php
@@ -3,7 +3,7 @@
 
 /**
  * HTML class for a submit type element
- * 
+ *
  * PHP versions 4 and 5
  *
  * LICENSE: This source file is subject to version 3.01 of the PHP license
@@ -29,7 +29,7 @@ require_once 'HTML/QuickForm/input.php';
 
 /**
  * HTML class for a submit type element
- * 
+ *
  * @category    HTML
  * @package     HTML_QuickForm
  * @author      Adam Daniel <adaniel1@eesus.jnj.com>
@@ -43,7 +43,7 @@ class HTML_QuickForm_submit extends HTML_QuickForm_input
 
     /**
      * Class constructor
-     * 
+     *
      * @param     string    Input field name attribute
      * @param     string    Input field value
      * @param     mixed     Either a typical HTML attribute string or an associative array
@@ -57,13 +57,13 @@ class HTML_QuickForm_submit extends HTML_QuickForm_input
         $this->setValue($value);
         $this->setType('submit');
     } //end constructor
-    
+
     // }}}
     // {{{ freeze()
 
     /**
      * Freeze the element so that only its value is returned
-     * 
+     *
      * @access    public
      * @return    void
      */

--- a/HTML/QuickForm/text.php
+++ b/HTML/QuickForm/text.php
@@ -3,7 +3,7 @@
 
 /**
  * HTML class for a text field
- * 
+ *
  * PHP versions 4 and 5
  *
  * LICENSE: This source file is subject to version 3.01 of the PHP license
@@ -29,7 +29,7 @@ require_once 'HTML/QuickForm/input.php';
 
 /**
  * HTML class for a text field
- * 
+ *
  * @category    HTML
  * @package     HTML_QuickForm
  * @author      Adam Daniel <adaniel1@eesus.jnj.com>
@@ -39,15 +39,15 @@ require_once 'HTML/QuickForm/input.php';
  */
 class HTML_QuickForm_text extends HTML_QuickForm_input
 {
-                
+
     // {{{ constructor
 
     /**
      * Class constructor
-     * 
+     *
      * @param     string    $elementName    (optional)Input field name attribute
      * @param     string    $elementLabel   (optional)Input field label
-     * @param     mixed     $attributes     (optional)Either a typical HTML attribute string 
+     * @param     mixed     $attributes     (optional)Either a typical HTML attribute string
      *                                      or an associative array
      * @since     1.0
      * @access    public
@@ -59,13 +59,13 @@ class HTML_QuickForm_text extends HTML_QuickForm_input
         $this->_persistantFreeze = true;
         $this->setType('text');
     } //end constructor
-        
+
     // }}}
     // {{{ setSize()
 
     /**
      * Sets size of text field
-     * 
+     *
      * @param     string    $size  Size of text field
      * @since     1.3
      * @access    public
@@ -81,7 +81,7 @@ class HTML_QuickForm_text extends HTML_QuickForm_input
 
     /**
      * Sets maxlength of text field
-     * 
+     *
      * @param     string    $maxlength  Maximum length of text field
      * @since     1.3
      * @access    public
@@ -93,6 +93,6 @@ class HTML_QuickForm_text extends HTML_QuickForm_input
     } //end func setMaxlength
 
     // }}}
-    
+
 } //end class HTML_QuickForm_text
 ?>

--- a/HTML/QuickForm/textarea.php
+++ b/HTML/QuickForm/textarea.php
@@ -3,7 +3,7 @@
 
 /**
  * HTML class for a textarea type field
- * 
+ *
  * PHP versions 4 and 5
  *
  * LICENSE: This source file is subject to version 3.01 of the PHP license
@@ -24,12 +24,12 @@
 
 /**
  * Base class for form elements
- */ 
+ */
 require_once 'HTML/QuickForm/element.php';
 
 /**
  * HTML class for a textarea type field
- * 
+ *
  * @category    HTML
  * @package     HTML_QuickForm
  * @author      Adam Daniel <adaniel1@eesus.jnj.com>
@@ -51,10 +51,10 @@ class HTML_QuickForm_textarea extends HTML_QuickForm_element
 
     // }}}
     // {{{ constructor
-        
+
     /**
      * Class constructor
-     * 
+     *
      * @param     string    Input field name attribute
      * @param     mixed     Label(s) for a field
      * @param     mixed     Either a typical HTML attribute string or an associative array
@@ -68,13 +68,13 @@ class HTML_QuickForm_textarea extends HTML_QuickForm_element
         $this->_persistantFreeze = true;
         $this->_type = 'textarea';
     } //end constructor
-    
+
     // }}}
     // {{{ setName()
 
     /**
      * Sets the input field name
-     * 
+     *
      * @param     string    $name   Input field name attribute
      * @since     1.0
      * @access    public
@@ -84,13 +84,13 @@ class HTML_QuickForm_textarea extends HTML_QuickForm_element
     {
         $this->updateAttributes(array('name'=>$name));
     } //end func setName
-    
+
     // }}}
     // {{{ getName()
 
     /**
      * Returns the element name
-     * 
+     *
      * @since     1.0
      * @access    public
      * @return    string
@@ -105,7 +105,7 @@ class HTML_QuickForm_textarea extends HTML_QuickForm_element
 
     /**
      * Sets value for textarea element
-     * 
+     *
      * @param     string    $value  Value for textarea element
      * @since     1.0
      * @access    public
@@ -115,7 +115,7 @@ class HTML_QuickForm_textarea extends HTML_QuickForm_element
     {
         $this->_value = $value;
     } //end func setValue
-    
+
     // }}}
     // {{{ getValue()
 
@@ -136,7 +136,7 @@ class HTML_QuickForm_textarea extends HTML_QuickForm_element
 
     /**
      * Sets wrap type for textarea element
-     * 
+     *
      * @param     string    $wrap  Wrap type
      * @since     1.0
      * @access    public
@@ -146,13 +146,13 @@ class HTML_QuickForm_textarea extends HTML_QuickForm_element
     {
         $this->updateAttributes(array('wrap' => $wrap));
     } //end func setWrap
-    
+
     // }}}
     // {{{ setRows()
 
     /**
      * Sets height in rows for textarea element
-     * 
+     *
      * @param     string    $rows  Height expressed in rows
      * @since     1.0
      * @access    public
@@ -168,12 +168,12 @@ class HTML_QuickForm_textarea extends HTML_QuickForm_element
 
     /**
      * Sets width in cols for textarea element
-     * 
+     *
      * @param     string    $cols  Width expressed in cols
      * @since     1.0
      * @access    public
      * @return    void
-     */ 
+     */
     function setCols($cols)
     {
         $this->updateAttributes(array('cols' => $cols));
@@ -184,7 +184,7 @@ class HTML_QuickForm_textarea extends HTML_QuickForm_element
 
     /**
      * Returns the textarea element in HTML
-     * 
+     *
      * @since     1.0
      * @access    public
      * @return    string
@@ -201,13 +201,13 @@ class HTML_QuickForm_textarea extends HTML_QuickForm_element
                    '</textarea>';
         }
     } //end func toHtml
-    
+
     // }}}
     // {{{ getFrozenHtml()
 
     /**
      * Returns the value of field without HTML tags (in this case, value is changed to a mask)
-     * 
+     *
      * @since     1.0
      * @access    public
      * @return    string

--- a/HTML/QuickForm/xbutton.php
+++ b/HTML/QuickForm/xbutton.php
@@ -3,7 +3,7 @@
 
 /**
  * Class for HTML 4.0 <button> element
- * 
+ *
  * PHP versions 4 and 5
  *
  * LICENSE: This source file is subject to version 3.01 of the PHP license
@@ -23,12 +23,12 @@
 
 /**
  * Base class for form elements
- */ 
+ */
 require_once 'HTML/QuickForm/element.php';
 
 /**
  * Class for HTML 4.0 <button> element
- * 
+ *
  * @category    HTML
  * @package     HTML_QuickForm
  * @author      Alexey Borzov <avb@php.net>
@@ -42,11 +42,11 @@ class HTML_QuickForm_xbutton extends HTML_QuickForm_element
     * @var      string
     * @access   private
     */
-    var $_content; 
+    var $_content;
 
    /**
     * Class constructor
-    * 
+    *
     * @param    string  Button name
     * @param    string  Button content (HTML to add between <button></button> tags)
     * @param    mixed   Either a typical HTML attribute string or an associative array
@@ -82,7 +82,7 @@ class HTML_QuickForm_xbutton extends HTML_QuickForm_element
     function setName($name)
     {
         $this->updateAttributes(array(
-            'name' => $name 
+            'name' => $name
         ));
     }
 
@@ -137,7 +137,7 @@ class HTML_QuickForm_xbutton extends HTML_QuickForm_element
 
    /**
     * Returns a 'safe' element's value
-    * 
+    *
     * The value is only returned if the button's type is "submit" and if this
     * particlular button was clicked
     */

--- a/HTML/Template/ITX.php
+++ b/HTML/Template/ITX.php
@@ -394,23 +394,23 @@ class HTML_Template_ITX extends HTML_Template_IT
         reset($this->functions);
         while (list($func_id, $function) = each($this->functions)) {
             if (isset($this->callback[$function['name']])) {
-                if ($this->callback[$function['name']]['expandParameters']) { 
+                if ($this->callback[$function['name']]['expandParameters']) {
                     $callFunction = 'call_user_func_array';
                 } else {
                     $callFunction = 'call_user_func';
                 }
 
                 if ($this->callback[$function['name']]['object'] != '') {
-                     $call = 
+                     $call =
                        $callFunction(
                         array(
                         &$GLOBALS[$this->callback[$function['name']]['object']],
                         $this->callback[$function['name']]['function']),
                         $function['args']
                        );
-                
+
                 } else {
-                     $call = 
+                     $call =
                        $callFunction(
                         $this->callback[$function['name']]['function'],
                         $function['args']
@@ -419,7 +419,7 @@ class HTML_Template_ITX extends HTML_Template_IT
                 $this->variableCache['__function' . $func_id . '__'] = $call;
             }
         }
-            
+
     } // end func performCallback
 
     /**
@@ -489,7 +489,7 @@ class HTML_Template_ITX extends HTML_Template_IT
     * @return     boolean   False on failure.
     * @throws     IT_Error
     * @access     public
-    * @deprecated The $callbackobject parameter is depricated since 
+    * @deprecated The $callbackobject parameter is depricated since
     *             version 1.2 and might be dropped in further versions.
     */
     function
@@ -665,7 +665,7 @@ class HTML_Template_ITX extends HTML_Template_IT
     /**
      * Truncates the given code from the first occurence of
      * $delimiter but ignores $delimiter enclosed by " or '.
-     * 
+     *
      * @access private
      * @param  string   The code which should be parsed
      * @param  string   The delimiter char

--- a/HTML/Template/IT_Error.php
+++ b/HTML/Template/IT_Error.php
@@ -21,7 +21,7 @@ require_once "PEAR.php";
 
 /**
 * IT[X] Error class
-* 
+*
 * @package HTML_Template_IT
 */
 class IT_Error extends PEAR_Error {
@@ -29,23 +29,23 @@ class IT_Error extends PEAR_Error {
 
   /**
   * Prefix of all error messages.
-  * 
-  * @var  string
+  *
+  * @var string
   */
   var $error_message_prefix = "IntegratedTemplate Error: ";
-  
+
   /**
   * Creates an cache error object.
-  * 
+  *
   * @param  string  error message
   * @param  string  file where the error occured
   * @param  string  linenumber where the error occured
   */
   function __construct($msg, $file = __FILE__, $line = __LINE__) {
-    
+
     parent::__construct(sprintf("%s [%s on line %d].", $msg, $file, $line));
-    
+
   } // end func IT_Error
-  
+
 } // end class IT_Error
 ?>


### PR DESCRIPTION
We have a situation where we have a proposed change (from @monishdeb ) that is hard to read because of the trailing spaces being stripped - this is hard to avoid for anyone using an IDE or decent editor since trailing whitespaces are against our standard.

OTOH the upstream QF package is basically dead so we don't gain from keeping in sync with it.

It is easier to review this if you add w=1 to the url - ie. https://github.com/civicrm/civicrm-packages/compare/master...eileenmcnaughton:white?expand=1&w=1

This is not a full whitespace tidy up - in fact line endings are still set to windows :-(
But, by stripping the trailing ones we make legible PRs much more possible

