### PR TITLE
Declare Subparts as array in mimePart to support PHP7.2

### DIFF
--- a/Mail/mimePart.php
+++ b/Mail/mimePart.php
@@ -89,7 +89,7 @@ class Mail_mimePart
     * @var array
     * @access private
     */
-    var $_subparts;
+    var $_subparts = [];
 
     /**
     * The output of this part after being built


### PR DESCRIPTION
@eileenmcnaughton @monishdeb this pulls out the minor commit from https://github.com/civicrm/civicrm-packages/pull/205 as the full upgrade appears to be causing significant test failures. This just defines subparts as an array as needed  to pass php7.2 count() issues