### PR TITLE
dev/core#117 Replace useage of deprecated function each with foreach …

### DIFF
--- a/Mail/mime.php
+++ b/Mail/mime.php
@@ -183,7 +183,7 @@ class Mail_mime
 
         // Update build parameters
         if (!empty($params) && is_array($params)) {
-            while (list($key, $value) = each($params)) {
+            foreach ($params as $key => $value) {
                 $this->_build_params[$key] = $value;
             }
         }
@@ -842,7 +842,7 @@ class Mail_mime
     function &get($params = null, $filename = null, $skip_head = false)
     {
         if (isset($params)) {
-            while (list($key, $value) = each($params)) {
+            foreach ($params as $key => $value) {
                 $this->_build_params[$key] = $value;
             }
         }
@@ -1283,7 +1283,7 @@ class Mail_mime
     function _encodeHeaders($input, $params = array())
     {
         $build_params = $this->_build_params;
-        while (list($key, $value) = each($params)) {
+        foreach ($params as $key => $value) {
             $build_params[$key] = $value;
         }
 

--- a/Mail/mimeDecode.php
+++ b/Mail/mimeDecode.php
@@ -260,7 +260,7 @@ class Mail_mimeDecode extends PEAR
         }
 
         reset($headers);
-        while (list($key, $value) = each($headers)) {
+        foreach($headers as $key => $value) {
             $headers[$key]['name'] = strtolower($headers[$key]['name']);
             switch ($headers[$key]['name']) {
 
@@ -273,7 +273,7 @@ class Mail_mimeDecode extends PEAR
                     }
 
                     if (isset($content_type['other'])) {
-                        while (list($p_name, $p_value) = each($content_type['other'])) {
+                        foreach ($content_type['other'] as $p_name => $p_value) {
                             $return->ctype_parameters[$p_name] = $p_value;
                         }
                     }
@@ -283,7 +283,7 @@ class Mail_mimeDecode extends PEAR
                     $content_disposition = $this->_parseHeaderValue($headers[$key]['value']);
                     $return->disposition   = $content_disposition['value'];
                     if (isset($content_disposition['other'])) {
-                        while (list($p_name, $p_value) = each($content_disposition['other'])) {
+                        foreach ($content_type['other'] as $p_name => $p_value) {
                             $return->d_parameters[$p_name] = $p_value;
                         }
                     }

--- a/Mail/mimePart.php
+++ b/Mail/mimePart.php
@@ -592,7 +592,7 @@ class Mail_mimePart
         $escape = '=';
         $output = '';
 
-        while (list($idx, $line) = each($lines)) {
+        foreach ($lines as $idx => $line) {
             $newline = '';
             $i = 0;
 


### PR DESCRIPTION
…in Mail/mime Mail/mimePart and Mail/mimeDecode

This is again another small pull out rather than trying to do the full upgrade of these packages as the full upgrade is having some issues This just removes the each() function in favor of foreach()