### PR TITLE
(NFC) Remove deprecated function use

### DIFF
--- a/HTML/QuickForm.php
+++ b/HTML/QuickForm.php
@@ -854,11 +854,11 @@ class HTML_QuickForm extends HTML_Common
             $base = substr($elementName, 0, $pos);
             $idx = explode('][', str_replace(["['", "']", '["', '"]'], ['[', ']', '[', ']'], substr($elementName, $pos + 1, -1)));
             if (isset($this->_submitValues[$base])) {
-                $value = CRM_Utils_Array::recursiveValue($this->_submitValues[$base], $idx);
+                $value = CRM_Utils_Array::pathGet($this->_submitValues[$base], $idx);
             }
 
             if ((is_array($value) || null === $value) && isset($this->_submitFiles[$base])) {
-                if (!CRM_Utils_Array::recursiveIsset($this->_submitFiles[$base], array_merge(['name'], $idx))) {
+                if (!CRM_Utils_Array::pathIsset($this->_submitFiles[$base], array_merge(['name'], $idx))) {
                     $fileValue = NULL;
                 }
                 else {
@@ -867,7 +867,7 @@ class HTML_QuickForm extends HTML_Common
                     foreach ($props as $prop) {
                         $fileValue = HTML_QuickForm::arrayMerge(
                           $fileValue,
-                          $this->_reindexFiles(CRM_Utils_Array::recursiveValue($this->_submitFiles[$base], array_merge([$prop], $idx)), $prop)
+                          $this->_reindexFiles(CRM_Utils_Array::pathGet($this->_submitFiles[$base], array_merge([$prop], $idx)), $prop)
                         );
                     }
                 }
@@ -1264,7 +1264,7 @@ class HTML_QuickForm extends HTML_Common
                         $this->_submitValues[$elName] = $this->_recursiveFilter($filter, $value);
                     } else {
                         $keys = explode('[', trim(str_replace(["['", "']", '["', '"]'], ['[', '', '[', ''], $elName), ']['));
-                        $this->_submitValues = CRM_Utils_Array::recursiveBuild($keys, $this->_recursiveFilter($filter, $value), $this->_submitValues);
+                        CRM_Utils_Array::pathSet($this->_submitValues, $keys, $this->_recursiveFilter($filter, $value));
                     }
                 }
             }
@@ -1549,7 +1549,7 @@ class HTML_QuickForm extends HTML_Common
                             $base = substr($target, 0, $pos);
                             $idx = explode('][', str_replace(["['", "']", '["', '"]'], ['[', ']', '[', ']'], substr($target, $pos + 1, -1)));
                             $idx = array_merge([$base, 'name'], $idx);
-                            $isUpload = CRM_Utils_Array::recursiveIsset($this->_submitFiles, $idx);
+                            $isUpload = CRM_Utils_Array::pathIsset($this->_submitFiles, $idx);
                         }
                         if ($isUpload && (!isset($submitValue['error']) || UPLOAD_ERR_NO_FILE == $submitValue['error'])) {
                             continue 2;

--- a/HTML/QuickForm/Renderer/ArraySmarty.php
+++ b/HTML/QuickForm/Renderer/ArraySmarty.php
@@ -261,9 +261,9 @@ class HTML_QuickForm_Renderer_ArraySmarty extends HTML_QuickForm_Renderer_Array
             unset($elAry['keys']);
             // where should we put this element...
             if (is_array($this->_currentGroup) && ('group' != $elAry['type'])) {
-                $this->_currentGroup = CRM_Utils_Array::recursiveBuild($keys, $elAry, $this->_currentGroup);
+                CRM_Utils_Array::pathSet($this->_currentGroup, $keys, $elAry);
             } else {
-                $this->_ary = CRM_Utils_Array::recursiveBuild($keys, $elAry, $this->_ary);
+                CRM_Utils_Array::pathSet($this->_ary, $keys, $elAry);
             }
         }
         return;

--- a/HTML/QuickForm/element.php
+++ b/HTML/QuickForm/element.php
@@ -345,7 +345,7 @@ class HTML_QuickForm_element extends HTML_Common
             return $values[$elementName];
         } elseif (strpos($elementName, '[')) {
             $keys = explode('[', str_replace(']', '', $elementName));
-            return CRM_Utils_Array::recursiveValue($values, $keys);
+            return CRM_Utils_Array::pathGet($values, $keys);
         } else {
             return null;
         }
@@ -475,7 +475,9 @@ class HTML_QuickForm_element extends HTML_Common
                 return array($name => $value);
             } else {
                 $keys = explode('[', str_replace(']', '', $name));
-                return CRM_Utils_Array::recursiveBuild($keys, $value);
+                $preparedValue = [];
+                CRM_Utils_Array::pathSet($preparedValue, $keys, $value);
+                return $preparedValue;
             }
         }
     }

--- a/HTML/QuickForm/file.php
+++ b/HTML/QuickForm/file.php
@@ -335,7 +335,7 @@ class HTML_QuickForm_file extends HTML_QuickForm_input
             $base = substr($elementName, 0, $pos);
             $idx = explode('][', str_replace(["['", "']", '["', '"]'], ['[', ']', '[', ']'], substr($elementName, $pos + 1, -1)));
             $idx = array_merge([$base, 'name'], $idx);
-            if (!CRM_Utils_Array::recursiveIsset($_FILES, $idx)) {
+            if (!CRM_Utils_Array::pathIsset($_FILES, $idx)) {
                 return NULL;
             }
             else {
@@ -343,7 +343,7 @@ class HTML_QuickForm_file extends HTML_QuickForm_input
                 $value = [];
                 foreach ($props as $prop) {
                     $idx[1] = $prop;
-                    $value[$prop] = CRM_Utils_Array::recursiveValue($_FILES, $idx);
+                    $value[$prop] = CRM_Utils_Array::pathGet($_FILES, $idx);
                 }
                 return $value;
             }

--- a/HTML/QuickForm/hierselect.php
+++ b/HTML/QuickForm/hierselect.php
@@ -230,8 +230,8 @@ class HTML_QuickForm_hierselect extends HTML_QuickForm_group
         $arrayKeys = [];
         foreach (array_keys($this->_elements) AS $key) {
           if (isset($this->_options[$key])) {
-            if ((empty($arrayKeys)) || CRM_Utils_Array::recursiveIsset($this->_options[$key], $arrayKeys)) {
-              $array = empty($arrayKeys) ? $this->_options[$key] : CRM_Utils_Array::recursiveValue($this->_options[$key], $arrayKeys);
+            if ((empty($arrayKeys)) || CRM_Utils_Array::pathIsset($this->_options[$key], $arrayKeys)) {
+              $array = empty($arrayKeys) ? $this->_options[$key] : CRM_Utils_Array::pathGet($this->_options[$key], $arrayKeys);
                 if (is_array($array)) {
                     $select =& $this->_elements[$key];
                     $select->_options = array();


### PR DESCRIPTION
Overview
----

Swaps around some functions introduced by @eileenmcnaughton and I for the non-deprecated equivalents. As @totten noted there was some redundancy, so as soon as this is merged I'll delete the other functions from core to keep things tidy.