### PR TITLE
dev/core#508 Fix misrepresentation of utf characters on export & other screens using hierSelect

### DIFF
--- a/HTML/QuickForm/hierselect.php
+++ b/HTML/QuickForm/hierselect.php
@@ -364,8 +364,7 @@ class HTML_QuickForm_hierselect extends HTML_QuickForm_group
             if ($js != '') {
                 $js .= ",\n";
             }
-            $options = utf8_encode($options);
-            $js .= '"'.$optValue.'":'.json_encode($options);
+            $js .= '"'.$optValue.'":'.json_encode($options, JSON_UNESCAPED_UNICODE);
         }
     }
 


### PR DESCRIPTION
Overview
------------------
Fixes mis-displayed characters (e.g accents) on some forms

Before
--------------------
![screenshot 2018-11-19 21 29 24](https://user-images.githubusercontent.com/336308/48694795-379f8d00-ec42-11e8-9724-9f76a660c831.png)


After
---------------------
![screenshot 2018-11-19 21 27 13](https://user-images.githubusercontent.com/336308/48694693-f14a2e00-ec41-11e8-905e-4457855535f7.png)

Comments
------------------
I wasn't able to replicate either https://issues.civicrm.org/jira/browse/CRM-21458 or https://lab.civicrm.org/dev/core/issues/292 afterwards.

I note that the fix for https://issues.civicrm.org/jira/browse/CRM-21458 tied in with the eval. Once eval went 292 was triggered & the fix for that triggered https://lab.civicrm.org/dev/core/issues/508