### PR TITLE
clear smarty cache generated from string input

### DIFF
--- a/Smarty/Smarty.class.php
+++ b/Smarty/Smarty.class.php
@@ -1298,6 +1298,11 @@ class Smarty
         }
         $this->_cache_including = $_cache_including;
 
+        // remove cache file if generated from string input
+        if ( preg_match( '/^(\s+)?string:/', $resource_name, $matches ) ) {
+            $this->_unlink($_smarty_compile_path);
+        }
+
         if ($display) {
             if (isset($_smarty_results)) { echo $_smarty_results; }
             if ($this->debugging) {


### PR DESCRIPTION
Clear Smarty Cache Generated from string input.

`$smarty->fetch("string:$htmlBody");`

Mass mailing use above call to generate final html for sending email. 
and pattern of cache file like e.g (Note : file name pattern get changed if mail open_tracking is disabled)

> en_US/%%32/320/32026E26%%open.php%3Fq%3D3807779%22+width%3D%271%27+height%3D%271%27+alt%3D%27%27+border%3D%270%27%3E.php

File size can vary 100-500 KB per file

This file get generated for each individual contact present in mailing.
 if total number of recipient are between 50-60K, disk space will get exhaust and CiviCRM will stop working until we clear the cache.

I know we have scheduled job to clear the template cache (with minimum 1 hr interval). but this job will remove entire CiviCRM cache which can be re-used for other templates files and not necessary to delete it.

This PR will delete the smarty cache generated from string input which can not be reused and resolved disk space issue.
