### PR TITLE
Change connection and results charsets to utf8mb4 on MySQL 5.5.3+

### DIFF
--- a/DB/DataObject.php
+++ b/DB/DataObject.php
@@ -2303,6 +2303,7 @@ class DB_DataObject extends DB_DataObject_Overload
         // change the connection and results charsets to UTF-8 if we're using MySQL 4.1+
         $civicrmConfig = CRM_Core_Config::singleton();
         $this->query("/*!40101 SET NAMES utf8 */");
+        $this->query("/*!50503 SET NAMES utf8mb4 */");
 
         if (!empty($_DB_DATAOBJECT['CONFIG']['debug'])) {
             $this->debug(serialize($_DB_DATAOBJECT['CONNECTIONS']), "CONNECT",5);


### PR DESCRIPTION
CiviCRM isn't using utf8mb4 yet, but let's start the process of migrating to utf8mb4... We can use utf8mb4 as the connection and results charset on MySQL 5.5.3+