### PR TITLE
(dev/joomla#9) htmlspecialchars() expects parameter 1 to be string

### DIFF
--- a/HTML/Common.php
+++ b/HTML/Common.php
@@ -134,17 +134,33 @@ class HTML_Common
      * @return   string
      * @access   private
      */
-    function _getAttrString($attributes)
-    {
-        $strAttr = '';
+    function _getAttrString($attributes)    {
+      $strAttr = '';
 
-        if (is_array($attributes)) {
-            $charset = HTML_Common::charset();
-            foreach ($attributes as $key => $value) {
-                $strAttr .= ' ' . $key . '="' . htmlspecialchars($value, ENT_COMPAT, $charset) . '"';
+      if (is_array($attributes)) {
+          $charset = HTML_Common::charset();
+          foreach ($attributes as $key => $value) {
+            // Sometimes $value is an array.  If so, we take concatenate 
+            // its elements.
+            if (is_array($value)) {
+              if (count($value) == 0) {
+                // An empty string.
+                $value1 = '';
+                $strAttr .= ' ' . $key . '="' . htmlspecialchars($value1, ENT_COMPAT, $charset) . '"';
+              }
+              else {
+                foreach ($value as $value1) {
+                  $strAttr .= ' ' . $key . '="' . htmlspecialchars($value1, ENT_COMPAT, $charset) . '"';
+                }
+              }
             }
-        }
-        return $strAttr;
+            else {
+              $strAttr .= ' ' . $key . '="' . htmlspecialchars($value, ENT_COMPAT, $charset) . '"';
+            }
+      }
+
+      }
+      return $strAttr;
     } // end func _getAttrString
 
     /**


### PR DESCRIPTION
This error can occur: htmlspecialchars() expects parameter 1 to be string, array given in .../administrator/components/com_civicrm/civicrm/packages/HTML/Common.php on line 144

The patch test to see if the value is an array.  If it is, it calls htmlspecialchars for each member.  If the array is empty it calls the same function with a null string.

See: [https://lab.civicrm.org/dev/joomla/issues/9](https://lab.civicrm.org/dev/joomla/issues/9)