### PR TITLE
expose smarty's compile_check to be overridden in civicrm.settings.php

### DIFF
--- a/Smarty/Smarty.class.php
+++ b/Smarty/Smarty.class.php
@@ -53,6 +53,10 @@ if (!defined('SMARTY_CORE_DIR')) {
     define('SMARTY_CORE_DIR', SMARTY_DIR . 'internals' . DIRECTORY_SEPARATOR);
 }
 
+if (!defined('SMARTY_COMPILE_CHECK')) {
+    define('SMARTY_COMPILE_CHECK', true);
+}
+
 define('SMARTY_PHP_PASSTHRU',   0);
 define('SMARTY_PHP_QUOTE',      1);
 define('SMARTY_PHP_REMOVE',     2);
@@ -138,7 +142,7 @@ class Smarty
      *
      * @var boolean
      */
-    var $compile_check   =  true;
+    var $compile_check   =  SMARTY_COMPILE_CHECK;
 
     /**
      * This forces templates to compile every time. Useful for development


### PR DESCRIPTION
Related issue [#1073](https://lab.civicrm.org/dev/core/issues/1073).

Smarty variable `compile_check` is hardcoded to **true** by default. This PR exposes it so can be set up to **false** in `civicrm.settings.php` for prod environments, which leads to a performance improvement in page rendering
