### PR TITLE
Improve deadlock error handling

### DIFF
--- a/DB/DataObject.php
+++ b/DB/DataObject.php
@@ -2415,16 +2415,22 @@ class DB_DataObject extends DB_DataObject_Overload
             $result = $DB->query($string);
           }
           catch (PEAR_Exception $e) {
+            if ($tries == 0) {
+              // The original sin was what triggered the retry. Sometimes the retry fails because mysql has done an internal rollback
+              // of previous queries in the transaction so it has essentially failed to recover from the deadlock. If we can't
+              // recover we should return the original error.
+              $firstError = $e;
+            }
             // CRM-21489 If we have caught a DB lock - let it go around the loop until our tries limit is hit.
             // else rethrow the exception. The 2 locks we are looking at are mysql code 1205 (lock) and
             // 1213 (deadlock).
             $dbErrorMessage = $e->getCause()->getUserInfo();
             if (!stristr($dbErrorMessage, 'nativecode=1205') && !stristr($dbErrorMessage, 'nativecode=1213')) {
-              throw $e;
+              throw $firstError;
             }
             $message = (stristr($dbErrorMessage, 'nativecode=1213') ? 'Database deadlock encountered' : 'Database lock encountered');
             if (($tries + 1) === $maxTries) {
-              throw new CRM_Core_Exception($message, 0, array('sql' => $string, 'trace' => $e->getTrace()));
+              throw new CRM_Core_Exception($message, 0, array('sql' => $string, 'trace' => $firstError->getTrace()));
             }
             CRM_Core_Error::debug_log_message("Retrying after $message hit on attempt " . ($tries + 1) . ' at query : ' . $string);
             continue;


### PR DESCRIPTION
This simply captures the error when the deadlock is first hit & then if the deadlock threshold it hit, causing an abort, it re-throws the original error - so the backtrace is retained. 

We have been running this in production for about 6 months and the errors have been more meaningful

(@seamuslee001 you might have an interest)