### PR TITLE
CRM-20455 - DB_common::modifyQuery() - Optimize

### DIFF
--- a/DB/common.php
+++ b/DB/common.php
@@ -1148,14 +1148,20 @@ class DB_common extends PEAR
      */
     function modifyQuery($query)
     {
+        // This section of code may run hundreds or thousands of times in a given request.
+        // Consequently, it is micro-optimized to use single lookup in typical case.
+        if (!isset(Civi::$statics['db_common_dispatcher'])) {
+            if (class_exists('Civi\Core\Container') && \Civi\Core\Container::isContainerBooted()) {
+                Civi::$statics['db_common_dispatcher'] = Civi\Core\Container::singleton()->get('dispatcher');
+            }
+            else {
+                return $query;
+            }
+        }
 
-      if (class_exists('Civi\Core\Container') && \Civi\Core\Container::isContainerBooted()) {
-        Civi\Core\Container::singleton()->get('dispatcher')->dispatch('civi.db.query',
-          \Civi\Core\Event\GenericHookEvent::create(array('query' => &$query))
-        );
-      }
-      return $query;
-
+        $e = new \Civi\Core\Event\QueryEvent($query);
+        Civi::$statics['db_common_dispatcher']->dispatch('civi.db.query', $e);
+        return $e->query;
     }
 
     // }}}


### PR DESCRIPTION
Overview
--------

The recently merged PR #180 added `modifyQuery()` to allow dynamic inspection/modification of most SQL queries (*post-boot*).

This patch modifies and micro-optimizes the new (unreleased) interface.

Ordinarily, one wouldn't care about this level of micro-optimization; however, it's entirely foreseeable that this code will run hundreds or even thousands of times while a user works with a single page.

__Depends__: https://github.com/civicrm/civicrm-core/pull/14882,  https://github.com/civicrm/civicrm-core/pull/14883

Before
------

For each typical SQL query, the call to `modifyQuery()` requires:

* Constructing an instance of `GenericHookEvent`, which does some   array shuffling and encourages reflective code.
* Performing multiple lookups of the container/dispatcher system

After
-----

For each typical SQL query, the call to `modifyQuery()` requires:

* Constructing an instance of `QueryEvent`, which is a lighter object
* Fewer lookups (`isset(Civi::$static[...])`)

Comments
--------

I did some simple benchmarks -- running 10,000 simple SQL queries with various forms of `modifyQuery()`.  The baseline (no events) had the fastest average (`9.444`s).  Adding GHE bumped runtime up +9% (`10.298`s).  With this patch, it only adds +3.5% (`9.787`s).

The averages are based on 5 samples each.  For full details, see https://gist.github.com/totten/da21a8386a7ddcc62def5d78e912bf8c