### PR TITLE
dev/core#772 fix php7.2 warnings on import

### DIFF
--- a/HTML/QuickForm/hierselect.php
+++ b/HTML/QuickForm/hierselect.php
@@ -259,7 +259,10 @@ class HTML_QuickForm_hierselect extends HTML_QuickForm_group
      */
     function setValue($value)
     {
-        $this->_nbElements = count($value);
+        // $value could be a string or an array - prior to php 7.2 count handled both, returning 0 for NULL
+        // or an empty array.
+        // https://stackoverflow.com/questions/20257983/why-the-count-function-returns-1-for-false-and-0-for-null
+        $this->_nbElements = is_array($value) ? count($value) : ($value === NULL ? 0 : 1);
         parent::setValue($value);
         $this->_setOptions();
     } // end func setValue


### PR DESCRIPTION
Overview
----------------------------------------
Fixed a notice when importing with php 7.2

This is replicable if you have an import file with the column 'Contact Source' among others & import setting it to
use 'Column Headers'. It correctly maps contact source & sets it as a default. 

Before
----------------------------------------
<img width="921" alt="Screen Shot 2019-08-12 at 12 00 15 PM" src="https://user-images.githubusercontent.com/336308/62841310-c08fb480-bcfa-11e9-9751-4c6a40e8120e.png">

After
----------------------------------------
No notice

Technical Details
----------------------------------------
The code in setValue
is open to either a string or an array but it uses count() in it's initial check - which was OK back when it was written
- nowadays count on a string puts out an error (but still returns 1) as per originally