### PR TITLE
INTL_IDNA_VARIANT_2003 deprecated in PHP_7.2

### DIFF
--- a/HTML/QuickForm/Rule/Email.php
+++ b/HTML/QuickForm/Rule/Email.php
@@ -55,7 +55,7 @@ class HTML_QuickForm_Rule_Email extends HTML_QuickForm_Rule
           if ($parts = explode('@', $email)) {
             if (sizeof($parts) == 2) {
               foreach ($parts as &$part) {
-                $part = idn_to_ascii($part);
+                $part = idn_to_ascii($part, 0, INTL_IDNA_VARIANT_UTS46);
               }
               $email = implode('@', $parts);
             }


### PR DESCRIPTION
INTL_IDNA_VARIANT_2003 is deprecated in php 7.2 but the function idn_to_ascii still uses it as default. 

It seems the only way to avoid the warning is calling the function using explicitly the parameter INTL_IDNA_VARIANT_UTS46.