### PR TITLE
Notice fixes on find participant.

### DIFF
--- a/HTML/QuickForm/select.php
+++ b/HTML/QuickForm/select.php
@@ -493,7 +493,7 @@ class HTML_QuickForm_select extends HTML_QuickForm_element {
             }
             $strHtml .= $tabs . '<select' . $attrString . ">\n";
 
-            $strValues = is_array($this->_values)? array_map('strval', $this->_values): array();
+            $strValues = (is_array($this->_values && !empty($this->_values)))? array_map('strval', $this->_values): array();
             foreach ($this->_options as $option) {
                 if (!empty($strValues) && in_array($option['attr']['value'], $strValues, true)) {
                     $option['attr']['selected'] = 'selected';


### PR DESCRIPTION
**Before**: On event find participants links throws notice on page as shown below attachment
<img width="965" alt="notice" src="https://user-images.githubusercontent.com/30790769/67574328-d89e9e00-f757-11e9-88fe-67b17c877b58.png">

**After:** The fix provided in PR removes the notice on event find participant page.