### PR TITLE
dev/core#1469 Mitigate for users that are running ICU 4.4 as the cons…

### DIFF
--- a/HTML/QuickForm/Rule/Email.php
+++ b/HTML/QuickForm/Rule/Email.php
@@ -37,6 +37,25 @@ require_once 'HTML/QuickForm/Rule.php';
  */
 class HTML_QuickForm_Rule_Email extends HTML_QuickForm_Rule
 {
+
+    /**
+     * Compatibility layer for PHP versions running ICU 4.4, as the constant INTL_IDNA_VARIANT_UTS46
+     * is only available as of ICU 4.6.
+     *
+     * Please note: Once PHP 7.4 is the minimum requirement, this method will vanish without further notice
+     * as it is recommended to use the native method instead, when working against a clean environment.
+     *
+     * @param string $part.
+     * @return string|bool
+     */
+    private static function idn_to_ascii($part)
+    {
+        if (defined('INTL_IDNA_VARIANT_UTS46')) {
+            return idn_to_ascii($part, 0, INTL_IDNA_VARIANT_UTS46);
+        }
+        return idn_to_ascii($part);
+    }
+
     // switching to a better regex as per CRM-40
     // var $regex = '/^((\"[^\"\f\n\r\t\v\b]+\")|([\w\!\#\$\%\&\'\*\+\-\~\/\^\`\|\{\}]+(\.[\w\!\#\$\%\&\'\*\+\-\~\/\^\`\|\{\}]+)*))@((\[(((25[0-5])|(2[0-4][0-9])|([0-1]?[0-9]?[0-9]))\.((25[0-5])|(2[0-4][0-9])|([0-1]?[0-9]?[0-9]))\.((25[0-5])|(2[0-4][0-9])|([0-1]?[0-9]?[0-9]))\.((25[0-5])|(2[0-4][0-9])|([0-1]?[0-9]?[0-9])))\])|(((25[0-5])|(2[0-4][0-9])|([0-1]?[0-9]?[0-9]))\.((25[0-5])|(2[0-4][0-9])|([0-1]?[0-9]?[0-9]))\.((25[0-5])|(2[0-4][0-9])|([0-1]?[0-9]?[0-9]))\.((25[0-5])|(2[0-4][0-9])|([0-1]?[0-9]?[0-9])))|((([A-Za-z0-9\-])+\.)+[A-Za-z\-]+))$/';
     var $regex = '/^([a-zA-Z0-9&_?\/`!|#*$^%=~{}+\'-]+|"([\x00-\x0C\x0E-\x21\x23-\x5B\x5D-\x7F]|\\[\x00-\x7F])*")(\.([a-zA-Z0-9&_?\/`!|#*$^%=~{}+\'-]+|"([\x00-\x0C\x0E-\x21\x23-\x5B\x5D-\x7F]|\\[\x00-\x7F])*"))*@([a-zA-Z0-9&_?\/`!|#*$^%=~{}+\'-]+|\[([\x00-\x0C\x0E-\x5A\x5E-\x7F]|\\[\x00-\x7F])*\])(\.([a-zA-Z0-9&_?\/`!|#*$^%=~{}+\'-]+|\[([\x00-\x0C\x0E-\x5A\x5E-\x7F]|\\[\x00-\x7F])*\]))*$/';
@@ -55,7 +74,7 @@ class HTML_QuickForm_Rule_Email extends HTML_QuickForm_Rule
           if ($parts = explode('@', $email)) {
             if (sizeof($parts) == 2) {
               foreach ($parts as &$part) {
-                $part = idn_to_ascii($part, 0, INTL_IDNA_VARIANT_UTS46);
+                $part = self::idn_to_ascii($part);
               }
               $email = implode('@', $parts);
             }


### PR DESCRIPTION
…tant is only defined in ICU 4.6

This mitigates for the possibility where some users their php-intl version is tied to ICU 4.4 or less and the new constant is only available in 4.6 