### PR TITLE
dev/core#1675 and dev/core#1695 - Revert part of DB package upgrade that is causing transaction issues

### DIFF
--- a/DB/DataObject.php
+++ b/DB/DataObject.php
@@ -2642,7 +2642,12 @@ class DB_DataObject extends DB_DataObject_Overload
         ) {
             if ($_DB_driver == 'DB') {
                 $DB->autoCommit(false);
-                $DB->simpleQuery('BEGIN');
+                // dev/core#1675 and dev/core#1695
+                // This was added when DB was upgraded in 5.23 but it's
+                // causing problems with CRM_Core_Transaction where some
+                // transactions aren't getting committed. It's not clear
+                // yet what the best fix is.
+                // $DB->simpleQuery('BEGIN');
             } else {
                 $DB->beginTransaction();
             }


### PR DESCRIPTION
Overview
----------------------------------------
In 5.23 the DB package was upgraded and part of that upgrade causes it to start a database transaction as soon as CRM_Core_Transaction is initialized, whereas before it wouldn't until a "manipulation" statement was issued. That's not necessarily bad, but seems incompatible with some transactions in civi.

https://lab.civicrm.org/dev/core/-/issues/1675

https://lab.civicrm.org/dev/core/-/issues/1695

Before
----------------------------------------
Adding a timeline messes up the last activity.
Submissions of custom fields from webform don't get created.

After
----------------------------------------
Hopefully this buys more time and heads off more similar issues until can figure out if there's a better way.

Technical Details
----------------------------------------
Lots of details in the tickets.

Comments
----------------------------------------
If going this route I'd remove the hack in [XMLProcessor/Process.php](https://github.com/civicrm/civicrm-core/pull/16926) that was a quickfix in 5.24 for the first issue.

I've done some minimal clicking around and haven't seen anything break yet.

Note that tests might not catch these since if running within a transaction it will still "see" the created entries even when not committed yet.