### PR TITLE
Add trigger for smarty error event

### DIFF
--- a/Smarty/Smarty.class.php
+++ b/Smarty/Smarty.class.php
@@ -1098,6 +1098,9 @@ class Smarty
     {
         $msg = htmlentities($error_msg);
         trigger_error("Smarty error: $msg", $error_type);
+        // Customised for CiviCRM - this allows us to capture the error messages
+        $event = new \Civi\Core\Event\SmartyErrorEvent($error_msg, $error_type);
+        \Civi::dispatcher()->dispatch('civi.smarty.error', $event);
     }
 
 


### PR DESCRIPTION
See https://github.com/civicrm/civicrm-core/pull/16918

They need to be merged at the same time.

We can't override this function in `CRM_Core_Smarty` because it actually gets triggered from the `Smarty_Compiler` class which is not inherited.

Previously smarty errors (such as parse errors) were silently ignored in most cases making debugging templates extremely difficult.