### PR TITLE
dev/core#1137 - Make ssl database connections without client certificates work in php7

### DIFF
--- a/DB/mysqli.php
+++ b/DB/mysqli.php
@@ -317,7 +317,8 @@ class DB_mysqli extends DB_common
                     $dsn['password'],
                     $dsn['database'],
                     $dsn['port'],
-                    $dsn['socket']))
+                    $dsn['socket'],
+                    MYSQLI_CLIENT_SSL))
             {
                 $this->connection = $init;
             }


### PR DESCRIPTION
https://lab.civicrm.org/dev/core/-/issues/1137. Also related to https://github.com/civicrm/civicrm-core/pull/17694 and I did some more investigating.

1. In php5 the only ssl-related value you would need to set is `ca=true` and mysqli_ssl_set and mysqli_real_connect will work without requiring client certificates.
2. In php7 this does not work. But if you set `ca` to an actual ca file (and use the correct hostname in real_connect) then it will work.
3. Alternatively in php7, you can do it without setting any certificate values but then you need MYSQLI_CLIENT_SSL in the real_connect call.

In either case in php7 note that it will be picky about the hostname you use in real_connect - it needs to match the cert used by the server.

So I see no reason not to set the CLIENT_SSL flag in this block (which only executes when you specify you want ssl) since then you have the choice of no client certificate (which will be the most common scenario), or you can choose to use certificates. My guess on why pear::DB does not set this is because it's from php5.

There is still more needed - see 17694 - but this will allow using without client certificates.

@seamuslee001 