### PR TITLE
user-interface#25 show thumbnail for file containing Parenthesis, hide file start with dot in upload directory

### DIFF
--- a/kcfinder/core/class/uploader.php
+++ b/kcfinder/core/class/uploader.php
@@ -430,7 +430,7 @@ class uploader {
             (
                 isset($this->config['_normalizeFilenames']) &&
                 $this->config['_normalizeFilenames'] &&
-                preg_match('/[^0-9a-z\.\- _]/si', $file)
+                preg_match('/[^0-9a-z\.\- _\(\)]/si', $file) // note `(1)` is added to file name when preventing overwrite
             )
         )
             return false;

--- a/kcfinder/lib/helper_dir.php
+++ b/kcfinder/lib/helper_dir.php
@@ -95,7 +95,7 @@ class dir {
             'types' => "all",   // Allowed: "all" or possible return values
                                 // of filetype(), or an array with them
             'addPath' => true,  // Whether to add directory path to filenames
-            'pattern' => '/./', // Regular expression pattern for filename
+            'pattern' => '/^[^\.].+/', // Regular expression pattern for filename , hide file start with .
             'followLinks' => true
         );
 


### PR DESCRIPTION
Using KCFinder , if you load same file again, kcfinder added number under Parenthesis, but this stop showing thumbnail for images.

e.g.
<img width="455" alt="Screenshot 2020-08-30 at 5 00 02 PM" src="https://user-images.githubusercontent.com/377735/91657887-7aaeb580-eae2-11ea-8bc7-e0f9b9626278.png">

After this, it will start showing thumbnail for images...

--------------------------------------------------------
https://lab.civicrm.org/dev/user-interface/-/issues/25