### PR TITLE
DB_DataObject - Read CIVICRM_DEBUG_LOG_QUERY correctly

### DIFF
--- a/DB/DataObject.php
+++ b/DB/DataObject.php
@@ -2758,7 +2758,7 @@ class DB_DataObject extends DB_DataObject_Overload
         $action = strtolower(substr(trim($queryString),0,6));
         // CRM-20445 ends
 
-        if (!empty($_DB_DATAOBJECT['CONFIG']['debug']) || defined('CIVICRM_DEBUG_LOG_QUERY')) {
+        if (!empty($_DB_DATAOBJECT['CONFIG']['debug']) || (defined('CIVICRM_DEBUG_LOG_QUERY') && CIVICRM_DEBUG_LOG_QUERY)) {
           $timeTaken = sprintf("%0.6f", microtime(TRUE) - $time);
           $alertLevel = $this->getAlertLevel($timeTaken);
           $message = "$alertLevel QUERY DONE IN $timeTaken  seconds.";
@@ -2774,7 +2774,7 @@ class DB_DataObject extends DB_DataObject_Overload
           else {
             echo $message .= " not quite sure why this query does not have more info";
           }
-          if (defined('CIVICRM_DEBUG_LOG_QUERY')) {
+          if ((defined('CIVICRM_DEBUG_LOG_QUERY') && CIVICRM_DEBUG_LOG_QUERY)) {
             CRM_Core_Error::debug_log_message($message, FALSE, 'sql_log');
           }
           else {


### PR DESCRIPTION
Before
------

Any value of CIVICRM_DEBUG_LOG_QUERY (even empty string) is considered TRUE.

After
-----

The value of CIVICRM_DEBUG_LOG_QUERY can be TRUE-ish or FALSE-ish.