### PR TITLE
Add hack to support buttonrama without change to code adding submit

### DIFF
--- a/HTML/QuickForm.php
+++ b/HTML/QuickForm.php
@@ -636,7 +636,26 @@ class HTML_QuickForm extends HTML_Common
            $elementObject->onQuickFormEvent('updateValue', null, $this);
         } else {
             $args = func_get_args();
-            $elementObject =& $this->_loadElement('addElement', $element, array_slice($args, 1));
+            if ($element === 'submit') {
+              // Hack to support https://github.com/civicrm/civicrm-core/pull/18410
+              // This can maybe get deprecation notices at some point.
+              $button = explode('_', $args[1]);
+              $type = array_pop($button);
+              $attrs = array_merge([
+                'name' => $args[2],
+                'type' => 'submit',
+                'class' => '',
+              ], $args[3]);
+              $attrs['class'] .= " crm-button crm-button-type-{$type} crm-button{$args[1]}";
+              $buttonContents = CRM_Core_Page::crmIcon('fa-check-circle')  . ' ' .  $args[2];
+              $elementObjects = &$this->createElement('xbutton', $args[1], $buttonContents, $attrs);
+              $this->setDefaultAction($args[1]);
+              $group = $this->addGroup([$elementObjects], $args[1], '', ['&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;'], FALSE);
+              return $group;
+            }
+            else {
+              $elementObject =& $this->_loadElement('addElement', $element, array_slice($args, 1));
+            }
             if (PEAR::isError($elementObject)) {
                 return $elementObject;
             }


### PR DESCRIPTION
This is a bit hacky but I looked at cividiscount & concluded we should support the existing
code if we could - if nothing else then to simplify messaging about buttonrama. With this change no change is required
to cividiscount (although I did put up another change to cividiscount which I found to be broken on a different issue https://github.com/civicrm/org.civicrm.module.cividiscount/pull/242)

Without this

<img width="533" alt="Screen Shot 2020-09-11 at 4 53 23 PM" src="https://user-images.githubusercontent.com/336308/92862868-5c847600-f44f-11ea-86d7-1fdaadf013c4.png">

With this

<img width="687" alt="Screen Shot 2020-09-11 at 4 47 42 PM" src="https://user-images.githubusercontent.com/336308/92862186-86896880-f44e-11ea-8afb-b0ce55853577.png">

Having figured this out I'm not 100% sure it was worth the work I put in :-). However, it does mean that no version specific code is required in extensions. I think only a small handle of extensions are affected (including on by @agh1 who I'm sure knows what to do) - but OTOH the way cividiscount does it is nasty & not having to change that right now feels like a bonus
