### PR TITLE
Throw exception instead of PHP fatal error so we can handle a parse error in CiviCRM

### DIFF
--- a/Smarty/Smarty.class.php
+++ b/Smarty/Smarty.class.php
@@ -1097,10 +1097,16 @@ class Smarty
     function trigger_error($error_msg, $error_type = E_USER_WARNING)
     {
         $msg = htmlentities($error_msg);
-        trigger_error("Smarty error: $msg", $error_type);
+
         // Customised for CiviCRM - this allows us to capture the error messages
         $event = new \Civi\Core\Event\SmartyErrorEvent($error_msg, $error_type);
         \Civi::dispatcher()->dispatch('civi.smarty.error', $event);
+        if ($error_type === E_USER_ERROR) {
+          throw new CRM_Core_Exception("Smarty error: $msg");
+        }
+        else {
+          trigger_error("Smarty error: $msg", $error_type);
+        }
     }
 
 


### PR DESCRIPTION
Calling `trigger_error` is problematic because for a parse error it triggers a PHP error which stops execution immediately and doesn't give chance for it to get logged or for it to be handled within CiviCRM.

A particular example of this is parsing messagetemplates that have smarty enabled. If you add some style tags eg.

```
<style type="text/css">body {
        margin: 0;
        padding: 0;
    }
</style>
```
that will trigger a fatal error in the smarty parser unless you wrap it in literal tags first. But you don't know to wrap it in literal tags because the error never makes it into the CiviCRM logs and gets 🐿️ed away by the default PHP error handler which, on a production site, is often configured to not log anything or is not accessible to the site administrator.