### PR TITLE
Fix brackets in DataObject

### DIFF
--- a/DB/DataObject.php
+++ b/DB/DataObject.php
@@ -1167,7 +1167,7 @@ class DB_DataObject extends DB_DataObject_Overload
             }
 
             // CRM-14986 starts
-            if (($v & DB_DATAOBJECT_DATE) || ($v & DB_DATAOBJECT_TIME) || $v & DB_DATAOBJECT_MYSQLTIMESTAMP) {
+            if (($v & DB_DATAOBJECT_DATE) || ($v & DB_DATAOBJECT_TIME) || ($v & DB_DATAOBJECT_MYSQLTIMESTAMP)) {
               if (strpos($this->$k, '-') !== FALSE) {
                 /*
                  * per CRM-14986 we have been having ongoing problems with the format returned from $dao->find(TRUE) NOT
@@ -1185,7 +1185,7 @@ class DB_DataObject extends DB_DataObject_Overload
             // DATE is empty... on a col. that can be null..
             // Also useful for MYSQLTIMESTAMP to stop NO_ZERO_DATE errors
             if (!$this->$k &&
-                    (($v & DB_DATAOBJECT_DATE) || (($v & DB_DATAOBJECT_TIME) || ($v & DB_DATAOBJECT_MYSQLTIMESTAMP))) &&
+                    (($v & DB_DATAOBJECT_DATE) || ($v & DB_DATAOBJECT_TIME) || ($v & DB_DATAOBJECT_MYSQLTIMESTAMP)) &&
                     !($v & DB_DATAOBJECT_NOTNULL)) {
 
                 $rightq .= " NULL ";


### PR DESCRIPTION
This fixes some brackets because in https://github.com/civicrm/civicrm-packages/pull/320 it added an extra set of `()` around the 2nd set of options which wasn't really needed here

ping @demeritcowboy @eileenmcnaughton 