### PR TITLE
[php8-compat] Fix calling method_exist with paremeter that is bool not an object in…

### DIFF
--- a/DB/DataObject.php
+++ b/DB/DataObject.php
@@ -2804,7 +2804,7 @@ class DB_DataObject extends DB_DataObject_Overload
         if (!empty($_DB_DATAOBJECT['CONFIG']['debug'])) {
             $this->debug(serialize($result), 'RESULT',5);
         }
-        if (method_exists($result, 'numRows')) {
+        if (is_object($result) && method_exists($result, 'numRows')) {
             if ($_DB_driver == 'DB') {
                 $DB->expectError(DB_ERROR_UNSUPPORTED);
             } else {


### PR DESCRIPTION
… php8

like https://github.com/civicrm/civicrm-core/pull/20443 this just adds a check to make sure that $result is actually a class object

ping @eileenmcnaughton @totten 