### PR TITLE
DB/DataObject: use mb_strtolower because in turkish, INSERT becomes Insert

### DIFF
--- a/DB/DataObject.php
+++ b/DB/DataObject.php
@@ -2717,7 +2717,8 @@ class DB_DataObject extends DB_DataObject_Overload
             continue;
           }
             } else {
-                switch (strtolower(substr(trim($string),0,6))) {
+                // civicrm-packages#324 Use mb function because if setlocale is set to tr_TR.utf8, INSERT would become Insert
+                switch (mb_strtolower(substr(trim($string),0,6))) {
 
                     case 'insert':
                     case 'update':
@@ -2754,8 +2755,9 @@ class DB_DataObject extends DB_DataObject_Overload
 
         // CRM-18093 starts.
         // CRM-20445 starts Strip any prepended comments
+        // civicrm-packages#324 Use mb function because if setlocale is set to tr_TR.utf8, INSERT would become Insert
         $queryString = (substr($string, 0, 2) === '/*') ? substr($string, strpos($string, '*/') + 2) : $string;
-        $action = strtolower(substr(trim($queryString),0,6));
+        $action = mb_strtolower(substr(trim($queryString),0,6));
         // CRM-20445 ends
 
         if (!empty($_DB_DATAOBJECT['CONFIG']['debug']) || (defined('CIVICRM_DEBUG_LOG_QUERY') && CIVICRM_DEBUG_LOG_QUERY)) {


### PR DESCRIPTION
To reproduce, make sure you have the Turkish locale enabled (`dpkg-reconfigure locales` and enable `tr_TR.utf8`), then you can test with:

```
$ php -r 'setlocale(LC_ALL, "tr_TR.utf8"); echo strtolower("INSERT") . "\n";'
Insert
$ php -r 'setlocale(LC_ALL, "tr_TR.utf8"); echo mb_strtolower("INSERT") . "\n";'
insert
```

Huge thanks to @demeritcowboy for the lead.