### PR TITLE
Also check timestamp types for update() when trying to update a timestamp field with a blank value

### DIFF
--- a/DB/DataObject.php
+++ b/DB/DataObject.php
@@ -1472,7 +1472,7 @@ class DB_DataObject extends DB_DataObject_Overload
             // DATE is empty... on a col. that can be null..
             // note: this may be usefull for time as well..
             if (!$this->$k &&
-                    (($v & DB_DATAOBJECT_DATE) || ($v & DB_DATAOBJECT_TIME)) &&
+                    (($v & DB_DATAOBJECT_DATE) || ($v & DB_DATAOBJECT_TIME) || ($v & DB_DATAOBJECT_MYSQLTIMESTAMP)) &&
                     !($v & DB_DATAOBJECT_NOTNULL)) {
 
                 $settings .= "$kSql = NULL ";


### PR DESCRIPTION
Overview
----------------------------------------
In https://github.com/civicrm/civicrm-packages/pull/319 insert() was patched to also look for timestamp db fields when inserting a blank date in a field that allows nulls. But update() was not also patched so it has the same problem with timestamp types.

Before
----------------------------------------
See unit test at https://github.com/civicrm/civicrm-core/pull/20891 - it fails with:
DB Error: unknown error
Incorrect datetime value: '0' for column `whatever` at row 1

After
----------------------------------------
stores null in the db

Technical Details
----------------------------------------
It only fails if sql_mode has NO_ZERO_DATE.

Comments
----------------------------------------
https://github.com/civicrm/civicrm-core/pull/20476
