### PR TITLE
Remove illegal character notice when downloading a vcard with a special character

### DIFF
--- a/Contact/Vcard/Build.php
+++ b/Contact/Vcard/Build.php
@@ -2063,7 +2063,7 @@ class Contact_Vcard_Build extends PEAR
                     $strlen = mb_strlen($line, 'UTF-8');
                 }
                 foreach ($charsets as $charset) {
-                    $iconvd = iconv('UTF-8', $charset, $line);
+                    $iconvd = iconv('UTF-8', $charset.'//IGNORE', $line);
                     if (strlen($iconvd) == $strlen) {
                         $lineCharset = $charset;
                         $line = $iconvd;


### PR DESCRIPTION
## How to reproduce

* Configure your CiviCRM, so that notices are shown.
* Select a contact with a special character in the name.  In the standard test set _Allan Müller_ is a good candidate.
* Select the action (1) vcard (2)
![vcard](https://user-images.githubusercontent.com/14834891/127978728-4dd9f49d-df14-40f1-a369-9c165bac1fe7.png)
* Now a vcard is downloaded on your local disk.
* Refresh your screen

## Before
A notice is shown
![notice2](https://user-images.githubusercontent.com/14834891/127978981-33f3018d-0d77-418a-9ce5-947656d8a243.png)

## After
The notice is not there

## Technical details

The `//IGNORE` option is documented at https://www.php.net/manual/en/function.iconv.php . Instead of throwing a notice, it just removes the illegal character. This makes the line shorter so the the test on length (after the change) is still valid.