### PR TITLE
Replace Drupal 9 user function, function getUsername is no more valid

### DIFF
--- a/kcfinder/integration/civicrm.php
+++ b/kcfinder/integration/civicrm.php
@@ -98,7 +98,7 @@ function authenticate_drupal8($config) {
     $connection = \Drupal::database();
     $query = $connection->query("SELECT uid FROM {sessions} WHERE sid = :sid", array(":sid" => \Drupal\Component\Utility\Crypt::hashBase64($session)));
     if (($uid = $query->fetchField()) > 0) {
-      $username = \Drupal\user\Entity\User::load($uid)->getUsername();
+      $username = \Drupal\user\Entity\User::load($uid)->getAccountName();
       if ($username) {
         $config->userSystem->loadUser($username);
       }


### PR DESCRIPTION
Drupal 9 no more support `getUsername` function, this lead to fatal error while accessing the images through kcfinder.

Supported function in Drupal 8 and Drupal9 is `getAccountName`.