### PR TITLE
Fixes dev/core#2769 remove quickform hack - we are no longer calling this rule

### DIFF
--- a/HTML/QuickForm/Rule/Email.php
+++ b/HTML/QuickForm/Rule/Email.php
@@ -37,28 +37,7 @@ require_once 'HTML/QuickForm/Rule.php';
  */
 class HTML_QuickForm_Rule_Email extends HTML_QuickForm_Rule
 {
-
-    /**
-     * Compatibility layer for PHP versions running ICU 4.4, as the constant INTL_IDNA_VARIANT_UTS46
-     * is only available as of ICU 4.6.
-     *
-     * Please note: Once PHP 7.4 is the minimum requirement, this method will vanish without further notice
-     * as it is recommended to use the native method instead, when working against a clean environment.
-     *
-     * @param string $part.
-     * @return string|bool
-     */
-    private static function idn_to_ascii($part)
-    {
-        if (defined('INTL_IDNA_VARIANT_UTS46')) {
-            return idn_to_ascii($part, 0, INTL_IDNA_VARIANT_UTS46);
-        }
-        return idn_to_ascii($part);
-    }
-
-    // switching to a better regex as per CRM-40
-    // var $regex = '/^((\"[^\"\f\n\r\t\v\b]+\")|([\w\!\#\$\%\&\'\*\+\-\~\/\^\`\|\{\}]+(\.[\w\!\#\$\%\&\'\*\+\-\~\/\^\`\|\{\}]+)*))@((\[(((25[0-5])|(2[0-4][0-9])|([0-1]?[0-9]?[0-9]))\.((25[0-5])|(2[0-4][0-9])|([0-1]?[0-9]?[0-9]))\.((25[0-5])|(2[0-4][0-9])|([0-1]?[0-9]?[0-9]))\.((25[0-5])|(2[0-4][0-9])|([0-1]?[0-9]?[0-9])))\])|(((25[0-5])|(2[0-4][0-9])|([0-1]?[0-9]?[0-9]))\.((25[0-5])|(2[0-4][0-9])|([0-1]?[0-9]?[0-9]))\.((25[0-5])|(2[0-4][0-9])|([0-1]?[0-9]?[0-9]))\.((25[0-5])|(2[0-4][0-9])|([0-1]?[0-9]?[0-9])))|((([A-Za-z0-9\-])+\.)+[A-Za-z\-]+))$/';
-    var $regex = '/^([a-zA-Z0-9&_?\/`!|#*$^%=~{}+\'-]+|"([\x00-\x0C\x0E-\x21\x23-\x5B\x5D-\x7F]|\\[\x00-\x7F])*")(\.([a-zA-Z0-9&_?\/`!|#*$^%=~{}+\'-]+|"([\x00-\x0C\x0E-\x21\x23-\x5B\x5D-\x7F]|\\[\x00-\x7F])*"))*@([a-zA-Z0-9&_?\/`!|#*$^%=~{}+\'-]+|\[([\x00-\x0C\x0E-\x5A\x5E-\x7F]|\\[\x00-\x7F])*\])(\.([a-zA-Z0-9&_?\/`!|#*$^%=~{}+\'-]+|\[([\x00-\x0C\x0E-\x5A\x5E-\x7F]|\\[\x00-\x7F])*\]))*$/';
+    var $regex = '/^((\"[^\"\f\n\r\t\v\b]+\")|([\w\!\#\$\%\&\'\*\+\-\~\/\^\`\|\{\}]+(\.[\w\!\#\$\%\&\'\*\+\-\~\/\^\`\|\{\}]+)*))@((\[(((25[0-5])|(2[0-4][0-9])|([0-1]?[0-9]?[0-9]))\.((25[0-5])|(2[0-4][0-9])|([0-1]?[0-9]?[0-9]))\.((25[0-5])|(2[0-4][0-9])|([0-1]?[0-9]?[0-9]))\.((25[0-5])|(2[0-4][0-9])|([0-1]?[0-9]?[0-9])))\])|(((25[0-5])|(2[0-4][0-9])|([0-1]?[0-9]?[0-9]))\.((25[0-5])|(2[0-4][0-9])|([0-1]?[0-9]?[0-9]))\.((25[0-5])|(2[0-4][0-9])|([0-1]?[0-9]?[0-9]))\.((25[0-5])|(2[0-4][0-9])|([0-1]?[0-9]?[0-9])))|((([A-Za-z0-9\-])+\.)+[A-Za-z\-]+))$/';
 
     /**
      * Validates an email address
@@ -70,17 +49,6 @@ class HTML_QuickForm_Rule_Email extends HTML_QuickForm_Rule
      */
     function validate($email, $checkDomain = false)
     {
-        if (function_exists('idn_to_ascii')) {
-          if ($parts = explode('@', $email)) {
-            if (sizeof($parts) == 2) {
-              foreach ($parts as &$part) {
-                $part = self::idn_to_ascii($part);
-              }
-              $email = implode('@', $parts);
-            }
-          }
-        }
-
         // Fix for bug #10799: add 'D' modifier to regex
         if (preg_match($this->regex . 'D', $email)) {
             if ($checkDomain && function_exists('checkdnsrr')) {


### PR DESCRIPTION
It adds to confusion and we generally try to get our packages back to 'stock'

https://lab.civicrm.org/dev/core/-/issues/2769#note_63305

UPDATE - I thought https://github.com/civicrm/civicrm-core/pull/21169#discussion_r694017240 was merged - needs to be merged first

@seamuslee001 this is a follow up to the changes I did for https://lab.civicrm.org/dev/core/-/issues/2769 - ie we no longer need to hack quickform because we are doing validation within CRM and hacking it has downsides

- confusion - per the gitlab
- makes people think that hacking packages is 'ok' since we did it in place x
- at some level all hacks need to be maintained & re-applied on upgrade - they have an ongoing cost

I don't know what over QF hacks we still have ....