### PR TITLE
Beautifier - avoid e_notice in php 7.4 when acting on first comment token

### DIFF
--- a/PHP/Beautifier.php
+++ b/PHP/Beautifier.php
@@ -1303,7 +1303,7 @@ class PHP_Beautifier implements PHP_Beautifier_Interface
     public function getPreviousTokenConstant($iPrev = 1)
     {
         $sToken = $this->getPreviousToken($iPrev);
-        return $sToken[0];
+        return $sToken[0] ?? NULL;
     }
     /**
      * Get the 'x' significant (non whitespace) previous token text


### PR DESCRIPTION
Running GenCode for e.g. a DAO gives an E_NOTICE when it tries to get the previous token while processing the header comment, since there is no previous token.