### PR TITLE
dev/drupal#179 - kcfinder - Explicit start of Drupal session

### DIFF
--- a/kcfinder/integration/civicrm.php
+++ b/kcfinder/integration/civicrm.php
@@ -104,6 +104,10 @@ function authenticate_drupal8($config) {
       }
     }
   }
+
+  // Start Drupal's own session now, so changes to $_SESSION won't get overwritten later
+  \Drupal::service('session')->start();
+
   // check if user has access permission...
   if (CRM_Core_Permission::check('access CiviCRM')) {
     return true;


### PR DESCRIPTION
## Before
https://lab.civicrm.org/dev/drupal/-/issues/179
After successful authentication, KCFINDER options added to `$_SESSION` will be overwritten when Drupal initializes the session.

## After
In this PR, session is started before those options are added in `checkAuthentication()` so they're preserved when they get checked in `\kcfinder\uploader::__construct()`.

This change should affect Drupal 8 and 9 only. Also this method would get called by `\CRM_Core_Config::singleton()->userSystem->getSessionId()` later anyway.