### PR TITLE
[KCFinder integration] Change working directory before trying to include CiviCRM settings file

### DIFF
--- a/kcfinder/integration/civicrm.php
+++ b/kcfinder/integration/civicrm.php
@@ -42,6 +42,7 @@ function checkAuthentication() {
     $current_cwd   = getcwd();
     $civicrm_root  = dirname(dirname(getcwd()));
     $authenticated = false;
+    chdir($civicrm_root);
     require_once "{$civicrm_root}/civicrm.config.php";
     require_once 'CRM/Core/Config.php';
 


### PR DESCRIPTION
... as otherwise, this fails for KCFinder scripts being one level deeper in the directory tree (`path/to/doc_root/web/libraries/civicrm/packages/kcfinder`) than `civicrm.config.php` expects (`../../../sites/default`).

Follow-up to #342 with relation to [dev/drupal#179](https://lab.civicrm.org/dev/drupal/-/issues/179), [dev/core#3419](https://lab.civicrm.org/dev/core/-/issues/3419) and [dev/civicrm-asset-plugin#4](https://lab.civicrm.org/dev/civicrm-asset-plugin/-/issues/4)