### PR TITLE
[REF][PHP8.1] Fix issue where  is meant to be a string in preg_match_all

### DIFF
--- a/Smarty/Smarty_Compiler.class.php
+++ b/Smarty/Smarty_Compiler.class.php
@@ -443,7 +443,7 @@ class Smarty_Compiler extends Smarty {
 
         $tag_command = $match[1];
         $tag_modifier = isset($match[2]) ? $match[2] : null;
-        $tag_args = isset($match[3]) ? $match[3] : null;
+        $tag_args = $match[3] ?? '';
 
         if (preg_match('~^' . $this->_num_const_regexp . '|' . $this->_obj_call_regexp . '|' . $this->_var_regexp . '$~', $tag_command)) {
             /* tag name is a variable or object */


### PR DESCRIPTION
This fixes a bug where when generating civicrm_data.mysql a depreciation shows up on php8.1

```
Deprecated: preg_match_all(): Passing null to parameter #2 ($subject) of type string is deprecated in /home/jenkins/bknix-edge/build/build-0/web/sites/all/modules/civicrm/packages/Smarty/Smarty_Compiler.class.php on line 1531

Call Stack:
    0.0004     426944   1. {main}() /home/jenkins/bknix-edge/build/build-0/web/sites/all/modules/civicrm/xml/GenCode.php:0
    0.0056    1085640   2. CRM_Core_CodeGen_Main->main() /home/jenkins/bknix-edge/build/build-0/web/sites/all/modules/civicrm/xml/GenCode.php:58
    0.1241    9385112   3. CRM_Core_CodeGen_Schema->run() /home/jenkins/bknix-edge/build/build-0/web/sites/all/modules/civicrm/CRM/Core/CodeGen/Main.php:132
    0.1745   10454736   4. CRM_Core_CodeGen_Schema->generateLocaleDataSql($locale = 'en_US') /home/jenkins/bknix-edge/build/build-0/web/sites/all/modules/civicrm/CRM/Core/CodeGen/Schema.php:38
    0.1746   10458696   5. CRM_Core_CodeGen_Util_Template->fetchConcat($inputs = [0 => 'civicrm_country.tpl', 1 => 'civicrm_state_province.tpl', 2 => 'civicrm_currency.tpl', 3 => 'civicrm_data.tpl', 4 => 'civicrm_navigation.tpl', 5 => 'c
ivicrm_version_sql.tpl']) /home/jenkins/bknix-edge/build/build-0/web/sites/all/modules/civicrm/CRM/Core/CodeGen/Schema.php:106
    0.1781   10838600   6. Smarty->fetch($resource_name = 'civicrm_data.tpl', $cache_id = ???, $compile_id = ???, $display = ???) /home/jenkins/bknix-edge/build/build-0/web/sites/all/modules/civicrm/CRM/Core/CodeGen/Util/Template.php:120
    0.1781   10855208   7. Smarty->_compile_resource($resource_name = 'civicrm_data.tpl', $compile_path = '/tmp/templates_c_kdzXL2.d/%%16^166^166AE87A%%civicrm_data.tpl.php') /home/jenkins/bknix-edge/build/build-0/web/sites/all/modules/c
ivicrm/packages/Smarty/Smarty.class.php:1271
    0.1782   11072992   8. Smarty->_compile_source($resource_name = 'civicrm_data.tpl', $source_content = '-- +--------------------------------------------------------------------+\n-- | Copyright CiviCRM LLC. All rights reserved.
                 |\n-- |                                                                    |\n-- | This work is published under the GNU AGPLv3 license with some      |\n-- | permitted exceptions and without any warranty. For full licens
e    |\n-- | and copyright information, see https://civicrm.org/licensing       |\n-- +----------------------------------------------------------', $compiled_content = NULL, $cache_include_path = '/tmp/templates_c_kdzXL2.d/%%16^166^166AE
87A%%civicrm_data.tpl.inc') /home/jenkins/bknix-edge/build/build-0/web/sites/all/modules/civicrm/packages/Smarty/Smarty.class.php:1432
    0.1782   11165608   9. Smarty_Compiler->_compile_file($resource_name = 'civicrm_data.tpl', $source_content = '-- +--------------------------------------------------------------------+\n-- | Copyright CiviCRM LLC. All rights reserved.                        |\n-- |                                                                    |\n-- | This work is published under the GNU AGPLv3 license with some      |\n-- | permitted exceptions and without any warranty. For full license    |\n-- | and copyright information, see https://civicrm.org/licensing       |\n-- +----------------------------------------------------------', $compiled_content = NULL) /home/jenkins/bknix-edge/build/build-0/web/sites/all/modules/civicrm/packages/Smarty/Smarty.class.php:1499
    0.2180   12568768  10. Smarty_Compiler->_compile_tag($template_tag = 'localize') /home/jenkins/bknix-edge/build/build-0/web/sites/all/modules/civicrm/packages/Smarty/Smarty_Compiler.class.php:307
    0.2180   12569336  11. Smarty_Compiler->_compile_block_tag($tag_command = 'localize', $tag_args = NULL, $tag_modifier = '', $output = '<?php ') /home/jenkins/bknix-edge/build/build-0/web/sites/all/modules/civicrm/packages/Smarty/Smarty_Compiler.class.php:580
    0.2180   12570088  12. Smarty_Compiler->_parse_attrs($tag_args = NULL) /home/jenkins/bknix-edge/build/build-0/web/sites/all/modules/civicrm/packages/Smarty/Smarty_Compiler.class.php:733
    0.2180   12578312  13. preg_match_all($pattern = '~(?:(?:(?:\\$\\w+(?:\\[\\$?[\\w\\.]+\\])*(?:\\.\\$?\\w+(?:\\[\\$?[\\w\\.]+\\])*)*(?:(?:[\\+\\*\\/\\%]|(?:-(?!>)))(?:(?:\\-?\\d+(?:\\.\\d+)?)|[\\$\\w\\.\\+\\-\\*\\/\\%\\d\\>\\[\\]])*)?(?:\\->(?:\\$?\\w+(?:\\[\\$?[\\w\\.]+\\])*(?:\\.\\$?\\w+(?:\\[\\$?[\\w\\.]+\\])*)*(?:(?:[\\+\\*\\/\\%]|(?:-(?!>)))(?:(?:\\-?\\d+(?:\\.\\d+)?)|[\\$\\w\\.\\+\\-\\*\\/\\%\\d\\>\\[\\]])*)?))+)(?:\\((?:(?:\\w+|(?:(?:(?:(?:\\$\\w+(?:\\[\\$?[\\w\\.]+\\])*(?:\\.\\$?\\w+(?:\\[\\$?[\\w\\.]+\\])*)*(?:(?:[\\+\\*\\/\\%]|(?:-(?!>)))(?:(?:\\-', $subject = NULL, $matches = NULL) /home/jenkins/bknix-edge/build/build-0/web/sites/all/modules/civicrm/packages/Smarty/Smarty_Compiler.class.php:1531
```
