### PR TITLE
DB_DataObject - Fix pervasive warnings on PHP 8.2

### DIFF
--- a/DB/DataObject.php
+++ b/DB/DataObject.php
@@ -210,7 +210,7 @@ if (!defined('DB_DATAOBJECT_NO_OVERLOAD')) {
  * @author   Alan Knowles <alan@akbkhome.com>
  * @since    PHP 4.0
  */
-
+#[AllowDynamicProperties]
 class DB_DataObject extends DB_DataObject_Overload
 {
    /**


### PR DESCRIPTION
See: https://wiki.php.net/rfc/deprecate_dynamic_properties