### PR TITLE
fixes core#4047 - htmlspecialchars called on empty array

### DIFF
--- a/HTML/Common.php
+++ b/HTML/Common.php
@@ -141,7 +141,7 @@ class HTML_Common
         if (is_array($attributes)) {
             $charset = HTML_Common::charset();
             foreach ($attributes as $key => $value) {
-                $strAttr .= ' ' . $key . '="' . htmlspecialchars(($value ?? ''), ENT_COMPAT, $charset) . '"';
+                $strAttr .= ' ' . $key . '="' . htmlspecialchars((is_array($value) ? '' : ($value ?? '')), ENT_COMPAT, $charset) . '"';
             }
         }
         return $strAttr;


### PR DESCRIPTION
Full details on https://lab.civicrm.org/dev/core/-/issues/4047, but basically - we are sometimes passing empty arrays to this function.  Seems like the other instances that were changed on #346 will always be strings, unlike this one.