### PR TITLE
Fix broken call to registerElementType in advmultiselect.php

### DIFF
--- a/HTML/QuickForm/advmultiselect.php
+++ b/HTML/QuickForm/advmultiselect.php
@@ -1169,9 +1169,4 @@ class HTML_QuickForm_advmultiselect extends HTML_QuickForm_select
         return $options;
     }
 }
-
-if (class_exists('HTML_QuickForm')) {
-    HTML_QuickForm::registerElementType('advmultiselect',
-        'HTML/QuickForm/advmultiselect.php', 'HTML_QuickForm_advmultiselect');
-}
 ?>


### PR DESCRIPTION
I've been testing some static analysis tools on the CiviCRM codebase and getting an error that `HTML_QuickForm::registerElementType` is being called statically, despite not being a static method. 

I'm not able to replicate the error whilst using CiviCRM directly, but the error is legitimate. I guess somewhere in Civi the error must be being suppressed...

A bit of digging shows that:

1. `registerElementType` is not actually called outside of `advmultiselect.php` (none of the other field types have a call to `registerElementType`.
2. All that `registerElementType` is adds the three arguments to `$GLOBALS['HTML_QUICKFORM_ELEMENT_TYPES']`. However, $GLOBALS['HTML_QUICKFORM_ELEMENT_TYPES'] is configured with  `advmultiselect` at the top of `QuickForm.php`. Therefore there is no need for `registerElementType` to be called.

Possibly `registerElementType` should actually be made static - I'm not sure if it's likely that third-party extensions are registering their own element types??

As an aside, this is my first contribution to `civicrm-packages`. Am I right in thinking we don't bother trying to raise issues like this with any upstream quickform repositories anymore?