### PR TITLE
(REF) Smarty - Fix PHP 8.1 warning in 'modifier.escape.php'

### DIFF
--- a/Smarty/plugins/modifier.escape.php
+++ b/Smarty/plugins/modifier.escape.php
@@ -23,7 +23,7 @@ function smarty_modifier_escape($string, $esc_type = 'html', $char_set = 'ISO-88
 {
     switch ($esc_type) {
         case 'html':
-            return htmlspecialchars($string, ENT_QUOTES, $char_set);
+            return htmlspecialchars($string ?: '', ENT_QUOTES, $char_set);
 
         case 'htmlall':
             return htmlentities($string, ENT_QUOTES, $char_set);


### PR DESCRIPTION
Steps to reproduce
------------------

* Use PHP 8.1 and D7 with a default logging policy (eg "All Messages" or "Errors and Warnings")
* Use "Search > Find Contacts"
* On the listing page, observe a bunch of warnings

Before
------

~15 warnings, including ~11 related to `modifier.escape.php`

After
-----

~4 warnings, none involving `modifier.escape.php`

Comment
----------

The numbers 