### PR TITLE
[REF][PHP8.2] Fix dynamic property in FileReader class of PHPGetText

### DIFF
--- a/PHPgettext/streams.php
+++ b/PHPgettext/streams.php
@@ -85,6 +85,7 @@ class FileReader {
   var $_pos;
   var $_fd;
   var $_length;
+  var $error;
 
   function __construct($filename) {
     if (file_exists($filename)) {


### PR DESCRIPTION
This aims to resolve test failures like https://test.civicrm.org/job/CiviCRM-Core-Edge/CIVIVER=master,label=bknix-tmp-edge/lastCompletedBuild/testReport/(root)/CRM_Core_I18n_LocaleTest/testPartialLocale_with_data_set__es_MX_full_support__partial_mode___/ ping @demeritcowboy @eileenmcnaughton 