### PR TITLE
[REF][PHP8.2] IDS fixes for dynamic property deprecation

### DIFF
--- a/IDS/Caching/Apc.php
+++ b/IDS/Caching/Apc.php
@@ -59,7 +59,7 @@ class IDS_Caching_Apc implements IDS_Caching_Interface
     /**
      * Cache configuration
      *
-     * @var array
+     * @var IDS_Init
      */
     private $config = null;
 
@@ -82,7 +82,7 @@ class IDS_Caching_Apc implements IDS_Caching_Interface
      * Constructor
      *
      * @param  string $type caching type
-     * @param  array  $init the IDS_Init object
+     * @param  IDS_Init  $init the IDS_Init object
      * 
      * @return void
      */

--- a/IDS/Caching/Memcached.php
+++ b/IDS/Caching/Memcached.php
@@ -92,7 +92,7 @@ class IDS_Caching_Memcached implements IDS_Caching_Interface
      * Constructor
      *
      * @param  string $type caching type
-     * @param  array  $init the IDS_Init object
+     * @param  IDS_Init  $init the IDS_Init object
      * 
      * @return void
      */

--- a/IDS/Filter.php
+++ b/IDS/Filter.php
@@ -51,6 +51,12 @@
  */
 class IDS_Filter
 {
+    /**
+     * Filter ID
+     *
+     * @var    integer
+     */
+    protected $id;
 
     /**
      * Filter rule

--- a/IDS/Log/Database.php
+++ b/IDS/Log/Database.php
@@ -115,7 +115,7 @@ class IDS_Log_Database implements IDS_Log_Interface
     /**
      * Prepared SQL statement
      *
-     * @var string
+     * @var PDOStatement
      */
     private $statement = null;
 
@@ -125,6 +125,13 @@ class IDS_Log_Database implements IDS_Log_Interface
      * @var string
      */
     private $ip = 'local/unknown';
+
+    /**
+     * Holds current HTTP_X_FORWARDED_FOR address
+     *
+     * @var string
+     */
+    private $ip2 = '';
 
     /**
      * Instance container

--- a/IDS/Log/Email.php
+++ b/IDS/Log/Email.php
@@ -74,6 +74,13 @@ class IDS_Log_Email implements IDS_Log_Interface
     protected $headers = null;
 
     /**
+     * Optional envelope string
+     *
+     * @var string
+     */
+    protected $envelope = null;
+
+    /**
      * Safemode switch
      *
      * Using this switch it is possible to enable safemode, which is a spam
@@ -160,7 +167,6 @@ class IDS_Log_Email implements IDS_Log_Interface
         } elseif (is_array($config)) {
             $this->recipients[]      = $config['recipients'];
             $this->subject           = $config['subject'];
-            $this->additionalHeaders = $config['header'];
         }
 
         // determine correct IP address and concat them if necessary

--- a/IDS/Monitor.php
+++ b/IDS/Monitor.php
@@ -162,6 +162,13 @@ class IDS_Monitor
      */
     private $tmpJsonString = '';
 
+    /**
+     * Centrifuge data
+     * 
+     * @var array
+     */
+    public $centrifuge = [];
+
 
     /**
      * Constructor


### PR DESCRIPTION
In PHP 8.2 dynamic properties are deprecated: https://php.watch/versions/8.2/dynamic-properties-deprecated. Some tests on PHP 8.2 are failing due to deprecation notices coming from IDS (and the deprecations would occur in general usage of CiviCRM.

The upstream library does not seem to be maintained, and PHP 8.1 patches were applied direct to CiviCRM packages. Therefore I have not opened an upstream PR.

Whilst I was here I also fixed some bad PHPDoc comments.