### PR TITLE
[REF][PHP8.2] Resolve PHP8.2 Dynamic property issues by declaring pro…

### DIFF
--- a/TbsZip/tbszip.php
+++ b/TbsZip/tbszip.php
@@ -17,6 +17,26 @@ define('TBSZIP_STRING',32);    // output to string, or add from string
 
 class clsTbsZip {
 
+  private $Meth8Ok;
+  private $DisplayError;
+  private $Error;
+  private $ArchFile;
+  private $ArchIsNew;
+  private $CdEndPos;
+  private $CdPos;
+  private $CdInfo;
+  private $ArchHnd;
+  private $ArchIsStream;
+  private $AddInfo;
+  private $ReplInfo;
+  private $ReplByPos;
+  private $VisFileLst;
+  private $CdFileNbr;
+  private $CdFileByName;
+  private $CdFileLst;
+  private $LastReadIdx;
+  private $LastReadComp;
+
 	function __construct() {
 		$this->Meth8Ok = extension_loaded('zlib'); // check if Zlib extension is available. This is need for compress and uncompress with method 8.
 		$this->DisplayError = true;


### PR DESCRIPTION
…perties on the class

This aims to resolve the test failure 

```
CRM_Contact_Form_Task_PrintDocumentTest::testPrintDocument
Creation of dynamic property clsTbsZip::$Meth8Ok is deprecated

/home/homer/buildkit/build/build-2/web/sites/all/modules/civicrm/packages/TbsZip/tbszip.php:21
```

ping @demeritcowboy @eileenmcnaughton 