### PR TITLE
(alternate to #360) Avoid null warning for smarty escape modifier

### DIFF
--- a/Smarty/plugins/modifier.escape.php
+++ b/Smarty/plugins/modifier.escape.php
@@ -21,6 +21,9 @@
  */
 function smarty_modifier_escape($string, $esc_type = 'html', $char_set = 'ISO-8859-1')
 {
+    if ($string === NULL) {
+        return '';
+    }
     switch ($esc_type) {
         case 'html':
             return htmlspecialchars($string, ENT_QUOTES, $char_set);


### PR DESCRIPTION
As noted in #360 there's a lot of these. And they appear on several pages, and in my opinion is the least useful of the new php warnings. When escaping output there's almost never a semantic difference between null and "". For input, sure sometimes, like null might mean skip this field whereas blank might mean overwrite the existing value with blank. But this function is only used to _escape output_.

There is the downside that it might hide something that is null that shouldn't be, but there'll still be a separate warning if that variable is completely missing.

Figured I'd put this up while everyone's on the php warnings bandwagon.

Aside: This issue also makes writing unit tests for some screens difficult, because it keeps hitting this first and failing. Yes could try to fix each instance, but see start of description above.

@seamuslee001 @totten 