### PR TITLE
Smarty - Fix e-notice in modifier.escape.php

### DIFF
--- a/Smarty/plugins/modifier.escape.php
+++ b/Smarty/plugins/modifier.escape.php
@@ -21,6 +21,11 @@
  */
 function smarty_modifier_escape($string, $esc_type = 'html', $char_set = 'ISO-8859-1')
 {
+    // Early return for null, '', or '0', none of which need to be escaped and null will cause e-notices.
+    if (empty($string)) {
+        return (string) $string;
+    }
+
     switch ($esc_type) {
         case 'html':
             return htmlspecialchars($string, ENT_QUOTES, $char_set);


### PR DESCRIPTION
Overview
-----------
Fixes an ugly e-notice.
FWIW I've also submitted this PR upstream to https://github.com/smarty-php/smarty/pull/892

Before
-------
![image](https://github.com/civicrm/civicrm-packages/assets/2874912/2a87a359-c426-4a37-b58d-52db7be0538d)


After
------
![image](https://github.com/civicrm/civicrm-packages/assets/2874912/80c4497f-5911-4735-b05b-000bd5ef4de6)
