### PR TITLE
kcfinder - Fix cookies when running on alt HTTP port

### DIFF
--- a/kcfinder/conf/config.php
+++ b/kcfinder/conf/config.php
@@ -101,7 +101,7 @@ $_CONFIG = array(
 
     'mime_magic' => "",
 
-    'cookieDomain' => "",
+    'cookieDomain' => preg_replace(';:\d+$;', '', $_SERVER['HTTP_HOST']),
     'cookiePath' => "",
     'cookiePrefix' => 'KCFINDER_',
 


### PR DESCRIPTION
Overview
------------

Fix a problem KCFinder where doesn't work with alternate HTTP ports (like `:8000`). Makes it unusable for local testing/triage/maintenance.

Before
---------

* Assigns `cookieDomain` a default value from `HTTP_HOST`
* Console shows multiple issues about setting/reading cookies. Buttons don't work.

![Screenshot from 2023-08-22 21-23-37](https://github.com/civicrm/civicrm-packages/assets/1336047/a17d6983-0964-4dc1-b716-029d35ebf690)

After
---------

* Assigns `cookieDomain` a default value from `HTTP_HOST`, minus the ports
* OK.

Comments
-------------

I spun up a demo site in case you want to `r-run` the pre-patch code. (<a href="http://site-list.test-1.civicrm.org:8001/?filter=demo-171-*">site info</a>)
