### PR TITLE
kcfinder - Fix PHP 8.1 warnings from fastImage

### DIFF
--- a/kcfinder/lib/class_fastImage.php
+++ b/kcfinder/lib/class_fastImage.php
@@ -202,6 +202,7 @@ class fastImage
   private function getChars($n)
   {
     $response = null;
+    $this->str = $this->str ?: ''; /* buffer should be a string */
 
     // do we need more data?
     if ($this->strpos + $n -1 >= strlen($this->str))


### PR DESCRIPTION
# Steps to reproduce

* Install Civi + D7 with PHP 8.1
* Open "New Mailing"
* In the HTML editor, click the image icon
* Click "Browse server"
* If there are no files, then upload a couple. (I see an an HTML and PNG.)
* Alternate between:
    * Clicking on different files.
    * Force-reloading the popup
    * Opening a separate window (`/civicrm/admin`) to display warnings

# Before

```
Deprecated function: strlen(): Passing null to parameter #1 ($string) of type string is deprecated in kcfinder\fastImage->getChars()
   (line 207 of /home/totten/bknix/build/dmaster/web/sites/all/modules/civicrm/packages/kcfinder/lib/class_fastImage.php).

Deprecated function: strlen(): Passing null to parameter #1 ($string) of type string is deprecated in kcfinder\fastImage->getChars()
   (line 211 of /home/totten/bknix/build/dmaster/web/sites/all/modules/civicrm/packages/kcfinder/lib/class_fastImage.php).
```

# After

No warnings

