### PR TITLE
Fix problem with file names.

### DIFF
--- a/smarty3/vendor/smarty/smarty/libs/sysplugins/smarty_internal_resource_file.php
+++ b/smarty3/vendor/smarty/smarty/libs/sysplugins/smarty_internal_resource_file.php
@@ -89,6 +89,7 @@ class Smarty_Internal_Resource_File extends Smarty_Resource
         // Some basenames contained carriage returs or new lines. At least
         // under Windows, this leads to illegal file names. The regular
         // expression removes new lines, carriage returns and tabs.
+    
         $basename = basename($source->filepath);
         return preg_replace( '/(\r\n)+|\r+|\n+|\t+/', '', $basename );
     }

--- a/smarty3/vendor/smarty/smarty/libs/sysplugins/smarty_internal_resource_file.php
+++ b/smarty3/vendor/smarty/smarty/libs/sysplugins/smarty_internal_resource_file.php
@@ -86,7 +86,11 @@ class Smarty_Internal_Resource_File extends Smarty_Resource
      */
     public function getBasename(Smarty_Template_Source $source)
     {
-        return basename($source->filepath);
+        // Some basenames contained carriage returs or new lines. At least
+        // under Windows, this leads to illegal file names. The regular
+        // expression removes new lines, carriage returns and tabs.
+        $basename = basename($source->filepath);
+        return preg_replace( '/(\r\n)+|\r+|\n+|\t+/', '', $basename );
     }
 
     /**

--- a/smarty3/vendor/smarty/smarty/libs/sysplugins/smarty_internal_resource_registered.php
+++ b/smarty3/vendor/smarty/smarty/libs/sysplugins/smarty_internal_resource_registered.php
@@ -96,6 +96,10 @@ class Smarty_Internal_Resource_Registered extends Smarty_Resource
      */
     public function getBasename(Smarty_Template_Source $source)
     {
-        return basename($source->name);
+        // Some basenames contained carriage returs or new lines. At least
+        // under Windows, this leads to illegal file names. The regular
+        // expression removes new lines, carriage returns and tabs.
+        $basename = basename($source->filepath);
+        return preg_replace( '/(\r\n)+|\r+|\n+|\t+/', '', $basename );
     }
 }

--- a/smarty3/vendor/smarty/smarty/libs/sysplugins/smarty_internal_resource_registered.php
+++ b/smarty3/vendor/smarty/smarty/libs/sysplugins/smarty_internal_resource_registered.php
@@ -99,6 +99,7 @@ class Smarty_Internal_Resource_Registered extends Smarty_Resource
         // Some basenames contained carriage returs or new lines. At least
         // under Windows, this leads to illegal file names. The regular
         // expression removes new lines, carriage returns and tabs.
+        
         $basename = basename($source->filepath);
         return preg_replace( '/(\r\n)+|\r+|\n+|\t+/', '', $basename );
     }


### PR DESCRIPTION
When running the latest version of CiviCRM (5.70alpha1) under IIS/Windows that some reports would not run because the system could not write a compiled template file. Investing this revealed that the process involves writing to a temporary file and then renaming it. This last step was failing because the destination file name contained line feeds or carriage returns. These were being put in by the getBasename function one or both of the changed files. This PR adds a preg_replace step that removes the offending characters (and tabs). Reports will now run.

It may be that there is a better fix, but this is at least a stopgap.