### PR TITLE
Allow more dynamic properties

### DIFF
--- a/smarty3/vendor/smarty/smarty/libs/sysplugins/smarty_internal_extension_handler.php
+++ b/smarty3/vendor/smarty/smarty/libs/sysplugins/smarty_internal_extension_handler.php
@@ -36,6 +36,16 @@
  * @property   Smarty_Internal_Method_RegisterPlugin     $registerPlugin
  * @property   mixed|\Smarty_Template_Cached             configLoad
  */
+/*
+ * Later versions of PHP deprecate dynamic properties in a class. Since it is
+ * possible, without a detailed knowledge of the code, that a variable we
+ * haven't declared might be a different class depending on the context,
+ * we add this line. See
+ * https://deycode.com/posts/
+ * how-to-fix-php-warning-deprecated-creation-of-dynamic-property-is-deprecated
+ */
+
+#[\AllowDynamicProperties]
 class Smarty_Internal_Extension_Handler
 {
     public $objType = null;
@@ -51,7 +61,6 @@ class Smarty_Internal_Extension_Handler
         'DebugTemplate'   => 0, 'RegisteredObject' => 0, 'StreamVariable' => 0,
         'TemplateVars'    => 0, 'Literals' => 'Literals',
     );//
-
     private $resolvedProperties = array();
 
     /**

--- a/smarty3/vendor/smarty/smarty/libs/sysplugins/smarty_internal_template.php
+++ b/smarty3/vendor/smarty/smarty/libs/sysplugins/smarty_internal_template.php
@@ -24,6 +24,16 @@
  *
  * @method bool mustCompile()
  */
+/*
+ * Later versions of PHP deprecate dynamic properties in a class. Since it is
+ * possible, without a detailed knowledge of the code, that a variable we
+ * haven't declared might be a different class depending on the context,
+ * we add this line. See
+ * https://deycode.com/posts/
+ * how-to-fix-php-warning-deprecated-creation-of-dynamic-property-is-deprecated
+ */
+
+#[\AllowDynamicProperties]
 class Smarty_Internal_Template extends Smarty_Internal_TemplateBase
 {
     /**
@@ -125,7 +135,6 @@ class Smarty_Internal_Template extends Smarty_Internal_TemplateBase
      * @var callback[]
      */
     public $endRenderCallbacks = array();
-
     /**
      * Create template data object
      * Some of the global Smarty settings copied to template scope

--- a/smarty3/vendor/smarty/smarty/libs/sysplugins/smarty_variable.php
+++ b/smarty3/vendor/smarty/smarty/libs/sysplugins/smarty_variable.php
@@ -7,6 +7,16 @@
  * @package    Smarty
  * @subpackage Template
  */
+/*
+ * Later versions of PHP deprecate dynamic properties in a class. Since it is
+ * possible, without a detailed knowledge of the code, that a variable we
+ * haven't declared might be a different class depending on the context,
+ * we add this line. See
+ * https://deycode.com/posts/
+ * how-to-fix-php-warning-deprecated-creation-of-dynamic-property-is-deprecated
+ */
+
+#[\AllowDynamicProperties]
 class Smarty_Variable
 {
     /**


### PR DESCRIPTION
Later versions of PHP deprecate having dynamic variables in the class constructors and CiviCRM complains when they are used. This PR allows the 'offending' code to use dynamic variables in the constructors, since, without knowing the code, it is possible that the same variable will have different properties depending on how it is called. Obviously, it would be better to declare them if one knew how it was being used.