### PR TITLE
dev/core#4955 Hack Smarty3+ getTemplateVars into Smarty2

### DIFF
--- a/Smarty/Smarty.class.php
+++ b/Smarty/Smarty.class.php
@@ -1068,6 +1068,22 @@ class Smarty
         }
     }
 
+  /**
+   * Returns a single or all template variables
+   *
+   * @api  Smarty::getTemplateVars()
+   * @link http://www.smarty.net/docs/en/api.get.template.vars.tpl
+   *
+   * @param string $varName variable name or NULL
+   * @param \Smarty_Internal_Data|\Smarty_Internal_Template|\Smarty $_ptr optional pointer to data object
+   * @param bool $searchParents include parent templates?
+   *
+   * @return mixed variable value or or array of variables
+   */
+  public function getTemplateVars($varName = NULL, Smarty_Internal_Data $_ptr = NULL, $searchParents = TRUE) {
+    return $this->get_template_vars($varName);
+  }
+
     /**
      * Returns an array containing config variables
      *


### PR DESCRIPTION
Per https://lab.civicrm.org/dev/core/-/issues/4955 overriding this function in a core compatibility class allows us to upgrade to Smarty3 & 4 but we hit a brick wall at 5.

Moving it into the package we plan on removing soon gets us past this (I will remove from the core SmartyCompatibily once this is merged).

Not sure if there are other functions - this is the blocking one ATM