### PR TITLE
[REF] Port Javascript escaping fix from Smarty v3 to Smarty v2

### DIFF
--- a/Smarty/plugins/modifier.escape.php
+++ b/Smarty/plugins/modifier.escape.php
@@ -67,7 +67,20 @@ function smarty_modifier_escape($string, $esc_type = 'html', $char_set = 'ISO-88
 
         case 'javascript':
             // escape quotes and backslashes, newlines, etc.
-            return strtr($string, array('\\'=>'\\\\',"'"=>"\\'",'"'=>'\\"',"\r"=>'\\r',"\n"=>'\\n','</'=>'<\/'));
+            return strtr($string, [
+                    '\\' => '\\\\',
+                    "'"  => "\\'",
+                    '"'  => '\\"',
+                    "\r" => '\\r',
+                    "\n" => '\\n',
+                    '</' => '<\/',
+                    // see https://html.spec.whatwg.org/multipage/scripting.html#restrictions-for-contents-of-script-elements
+                    '<!--' => '<\!--',
+                    '<s'   => '<\s',
+                    '<S'   => '<\S',
+	                "`" => "\\\\`",
+	                "\${" => "\\\\\\$\\{"
+                ]);
             
         case 'mail':
             // safe way to display e-mail address on a web page


### PR DESCRIPTION
This ports part of the patch from https://github.com/advisories/GHSA-7j98-h7fp-4vwj to Smarty v2 that seems relevant

@eileenmcnaughton @totten 