### PR TITLE
Fix setTemplateDir to actually work

### DIFF
--- a/Smarty/Smarty.class.php
+++ b/Smarty/Smarty.class.php
@@ -1107,8 +1107,8 @@ class Smarty
    *
    * @return \Smarty current Smarty instance for chaining
    */
-  public function setTemplateDir($template_dir, $isConfig = false) {
-    $this->addTemplateDir($template_dir, null, $isConfig);
+  public function setTemplateDir($template_dir) {
+    $this->template_dir = (array) $template_dir;
     return $this;
   }
 


### PR DESCRIPTION
Overview
-----

Fix broken backported function to support https://github.com/civicrm/civicrm-core/pull/30148

Before
------
Function creates garbage.

After
------
Function does what it's supposed to do.