### PR TITLE
kcfinder - Add support for Standalone

### DIFF
--- a/kcfinder/core/class/browser.php
+++ b/kcfinder/core/class/browser.php
@@ -157,7 +157,7 @@ class browser extends uploader {
             $this->sendDefaultThumb();
 
         $dir = $this->getDir();
-        $file = "{$this->thumbsTypeDir}/{$_GET['dir']}/${_GET['file']}";
+        $file = "{$this->thumbsTypeDir}/{$_GET['dir']}/{$_GET['file']}";
 
         // Create thumbnail
         if (!is_file($file) || !is_readable($file)) {

--- a/kcfinder/integration/civicrm.php
+++ b/kcfinder/integration/civicrm.php
@@ -69,6 +69,9 @@ function checkAuthentication() {
     case 'Drupal8':
       $auth_function = 'authenticate_drupal8';
       break;
+    case 'Standalone':
+      $auth_function = 'authenticate_standalone';
+      break;
     }
     if(!$auth_function($config)) {
       throw new CRM_Core_Exception(ts("You must be logged in with proper permissions to edit, add, or delete uploaded images."));
@@ -188,6 +191,10 @@ function authenticate_wordpress($config) {
     return true;
   }
   return false;
+}
+
+function authenticate_standalone($config) {
+  return CRM_Core_Permission::check('access CiviCRM');
 }
 
 function authenticate_joomla($config) {


### PR DESCRIPTION
ping @ufundo 

Steps to reproduce
--------------------

1. Install CiviCRM standalone (*esp. standard/tar-style layout*)
2. Create/update `core/civicrm.config.php`.  Depending on which PRs/layouts you're working with you, the content of this file may change. For example, if using current revision of @ufundo's 29960 with the simpler (non-composer) layout, then the file would need to say:
    ```php
    <?php
    chdir(dirname(__DIR__));
    require_once dirname(__DIR__) . '/civicrm.standalone.php';
    ```
3. Login
4. Go to "New Mailing" or "New Activity". Try to "Browse server" and/or "Upload" ("Send to server").

Before
-------

<img width="1158" alt="Screenshot 2024-06-12 at 8 29 58 AM" src="https://github.com/civicrm/civicrm-packages/assets/1336047/0a7231e1-425f-4856-9e6f-665d567d08e7">

After
-----

<img width="1046" alt="Screenshot 2024-06-12 at 8 31 53 AM" src="https://github.com/civicrm/civicrm-packages/assets/1336047/a7e50277-b3d3-4455-ba08-ab5b56e33a47">

Comments
------------

* Noticed this problem while trying to evaluate/confirm file-layouts.
* This is the same permisison-check used on WP, D7, D8+, BD.
* Yes, yes, of course `kcfinder` is the Spawn of Satan, the Destroyer of Worlds, the Eye-Burning Dragon, the Great Purveyor of Tortuous 1990's Iconography. If you can replace it with a 5 minute patch, great. But realistically, it's what we have right now. It's better if it doesn't crash. 😃