### PR TITLE
Allow enabling smarty escape by default with Smarty5

### DIFF
--- a/smarty5/EscapeModifierCompilerOverride.php
+++ b/smarty5/EscapeModifierCompilerOverride.php
@@ -1,0 +1,25 @@
+<?php
+
+use Smarty\Exception;
+use Smarty\Compile\Modifier\EscapeModifierCompiler;
+
+/**
+ * Smarty escape modifier plugin
+ * Type:     modifier
+ * Name:     escape
+ * Purpose:  escape string for output
+ *
+ * @author Rodney Rehm
+ */
+
+class EscapeModifierCompilerOverride extends EscapeModifierCompiler {
+  public function compile($params, \Smarty\Compiler\Template $compiler) {
+    $esc_type = $this->literal_compiler_param($params, 1, 'html');
+    if ($esc_type !== 'htmlall'
+    ) {
+      return parent::compile($params, $compiler);
+    }
+    return 'CRM_Core_Smarty::escape((string)' . $params[0] . ', "htmlall")';
+  }
+
+}

--- a/smarty5/EscapeOverrideExtension.php
+++ b/smarty5/EscapeOverrideExtension.php
@@ -1,0 +1,16 @@
+<?php
+
+  use Smarty\Extension\Base;
+
+   class EscapeOverrideExtension extends Base {
+
+  public function getModifierCompiler(string $modifier): ?\Smarty\Compile\Modifier\ModifierCompilerInterface {
+    require_once 'EscapeModifierCompilerOverride.php';
+    switch ($modifier) {
+      case 'escape': return new EscapeModifierCompilerOverride();
+    }
+
+    return NULL;
+  }
+
+}

--- a/smarty5/Smarty.php
+++ b/smarty5/Smarty.php
@@ -9,6 +9,17 @@ class Smarty {
 
   public function __construct() {
     $this->smarty = new Smarty\Smarty();
+    if (CRM_Utils_Constant::value('CIVICRM_SMARTY_DEFAULT_ESCAPE')) {
+      // See https://smarty-php.github.io/smarty/stable/api/extending/extensions/#writing-your-own-extension
+      require_once 'EscapeOverrideExtension.php';
+      $this->smarty->setExtensions([
+        new Smarty\Extension\CoreExtension(),
+        new EscapeOverrideExtension(),
+        new Smarty\Extension\DefaultExtension(),
+        new Smarty\Extension\BCPluginsAdapter($this->smarty),
+      ]);
+      $this->smarty->addDefaultModifiers( ['escape:"htmlall"']);
+    }
   }
 
   public function __call($name, $arguments) {


### PR DESCRIPTION
This makes Smarty5 respect the constant `CIVICRM_SMARTY_DEFAULT_ESCAPE` - this was something we were close to getting viable with Smarty2 but put on hold in order to work on updating smarty. It is not an option for Smarty3 & 4 & has no production usage in 2 but with this it can be enabled on 5 & with https://github.com/civicrm/civicrm-core/pull/30566 it loads without crashing 

https://github.com/civicrm/civicrm-core/pull/30567 & a larger one doing the same thing are required to get it to not have UI issues

I kept the class in packages as the main `Smarty` class is currently there to avoid conflict & it feels sane to keep it together - at some point we would move it to `\Civi\Smarty5\` I think but we need to cull smarty versions first

