### PR TITLE
KCFinder - look for civicrm.standalone.php as well as civicrm.config.php

### DIFF
--- a/kcfinder/integration/civicrm.php
+++ b/kcfinder/integration/civicrm.php
@@ -36,13 +36,32 @@
  *
  */
 
+
 function checkAuthentication() {
   static $authenticated;
   if ( !isset( $authenticated ) ) {
-    $current_cwd   = getcwd();
-    $civicrm_root  = dirname(dirname(getcwd()));
     $authenticated = false;
-    require_once "{$civicrm_root}/civicrm.config.php";
+
+    // used to chdir at the end of this function - not sure if necessary?
+    $current_cwd = getcwd();
+
+    function findConfigFile(string $search_path): string {
+      while ($search_path) {
+        foreach(['civicrm.config.php', 'civicrm.standalone.php'] as $config_filename) {
+          $config_file_candidate = $search_path . DIRECTORY_SEPARATOR . $config_filename;
+
+          if (file_exists($config_file_candidate)) {
+            return $config_file_candidate;
+          }
+        }
+
+        $search_path = dirname($search_path);
+      }
+
+      throw new \Exception('KCFinder couldn\'t find civicrm.config.php or civicrm.standalone.php to check authentication');
+    }
+
+    require_once findConfigFile(__DIR__);
     require_once 'CRM/Core/Config.php';
 
     $config = CRM_Core_Config::singleton();


### PR DESCRIPTION
Currently KCFinder is broken on Standalone because Standalone doesn't have a `civicrm.config.php` file, which the integration uses to boot CiviCRM to authenticate the user.

`civicrm.standalone.php` does the equivalent job - this patch looks for that as an alternative.

It searches up parent directories, which seemed the neatest way to support:
a) the existing case of `civicrm.config.php` in the civicrm-core folder, 
b) `civicrm.standalone.php` being in any parent directory (civicrm-core could be `core` or `vendor/civicrm/civicrm-core` relative to `civicrm.standalone.php`)
c) conceivable future permutations involving civicrm.config.php in a parent directory?

I wasn't sure why/if any of the previous `chdir` was still necessary - removing works for me but @totten do you know?

See also discussion on https://github.com/civicrm/civicrm-packages/pull/408

Note: KCFinder currently similarly broken out-of-box for D8+, (C) could be useful for fixing that