### PR TITLE
Fix PHPgettext fseek deprecation warnings in PHP 8.3

### DIFF
--- a/PHPgettext/streams.php
+++ b/PHPgettext/streams.php
@@ -105,7 +105,7 @@ class FileReader {
 
   function read($bytes) {
     if ($bytes) {
-      fseek($this->_fd, $this->_pos);
+      fseek($this->_fd, $this->_pos, SEEK_SET);
 
       // PHP 5.1.1 does not read more than 8192 bytes in one fread()
       // the discussions at PHP Bugs suggest it's the intended behaviour
@@ -122,7 +122,7 @@ class FileReader {
   }
 
   function seekto($pos) {
-    fseek($this->_fd, $pos);
+    fseek($this->_fd, $pos, SEEK_SET);
     $this->_pos = ftell($this->_fd);
     return $this->_pos;
   }


### PR DESCRIPTION
In PHP 8.3, passing null as the offset parameter to fseek() is deprecated. This commit adds the SEEK_SET parameter to the fseek() calls in the PHPgettext streams.php file to avoid these deprecation warnings.

The warning that appears without this fix is:
"fseek(): Passing null to parameter #2 () of type int is deprecated"