### PR TITLE
Handle smarty5 syntax for join/implode modifier so can support smarty2 at the same time without deprecations

### DIFF
--- a/Smarty/Smarty.class.php
+++ b/Smarty/Smarty.class.php
@@ -1879,6 +1879,15 @@ class Smarty
         [$_func_name, $_tpl_file, $_tpl_line] =
             $this->_plugins['modifier'][$_modifier_name];
 
+        // Patch so we can use join without deprecations in smarty5 while still
+        // supporting smarty2.
+        // Note that smarty2 only officially accepts the "backwards" (by smarty5
+        // standards) order, and so if it's already backwards, then we never
+        // even get here since it's handled elsewhere.
+        if ($_func_name === 'join' && is_string($_args[1])) {
+          return join($_args[1], $_args[0]);
+        }
+
         $_var = $_args[0];
         foreach ($_var as $_key => $_val) {
             $_args[0] = $_val;


### PR DESCRIPTION
The support matrix looks like this. "Modern syntax" means `{$x|join:','}`. Backwards, which is what is used everywhere currently is `{','|join:$x}`.

| | smarty2 | smarty5 |
| - | - | - |
| join with modern syntax | TypeError | ok |
| implode with modern syntax | TypeError | deprecation warning (implode is completely deprecated) |
| join with "backwards" syntax | ok | deprecation warning (about param ordering) |
| implode with "backwards" syntax | ok | deprecation warning (implode is completely deprecated) |

So the thing that makes sense to me is to try to support the first one in smarty2. Then when smarty2 is gone there's no further todos.

At the moment this PR is a no-op because
(a) as per the above table it's not possible that anywhere is using the modern syntax with smarty2, and
(b) this block of code is never hit when using the "backwards" syntax since it's handled elsewhere in smarty2.

See https://github.com/civicrm/civicrm-core/pull/32658 for the core PR that would use this.