### PR TITLE
Allow using smarty5 syntax for join modifier in smarty4

### DIFF
--- a/smarty4/vendor/smarty/smarty/libs/plugins/modifier.join.php
+++ b/smarty4/vendor/smarty/smarty/libs/plugins/modifier.join.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Smarty plugin
+ *
+ * @package    Smarty
+ * @subpackage PluginsModifier
+ */
+
+function smarty_modifier_join($values, $separator = '')
+{
+	if (is_array($separator)) {
+		return join((string) ($values ?? ''), (array) $separator);
+	}
+	return join((string) ($separator ?? ''), (array) $values);
+}


### PR DESCRIPTION
Same description as https://github.com/civicrm/civicrm-packages/pull/423 but replace 2 with 4.

