### PR TITLE
Cast configPath to string in init method - php8.5

### DIFF
--- a/IDS/Init.php
+++ b/IDS/Init.php
@@ -114,6 +114,7 @@ class IDS_Init
      */
     public static function init($configPath = null)
     {
+        $configPath = (string) $configPath;
         if (!isset(self::$instances[$configPath])) {
             self::$instances[$configPath] = new IDS_Init($configPath);
         }


### PR DESCRIPTION
Since configPath is allowed to be NULL it makes sense just to make that not cause a php notice

Upstream library not updated in 12 years & this is in packages -> hack away