### PR TITLE
[php8] semicolon in case statement

### DIFF
--- a/HTML/QuickForm/advmultiselect.php
+++ b/HTML/QuickForm/advmultiselect.php
@@ -499,7 +499,7 @@ class HTML_QuickForm_advmultiselect extends HTML_QuickForm_select
                                         $this->_parseAttributes($attributes));
             }
             break;
-        default;
+        default:
             return PEAR::throwError('Argument 1 of HTML_QuickForm_advmultiselect::' .
                        'setButtonAttributes has unexpected value',
                        HTML_QUICKFORM_ADVMULTISELECT_ERROR_INVALID_INPUT,


### PR DESCRIPTION
`Deprecated: Case statements followed by a semicolon (;) are deprecated, use a colon (:) instead`

It's a little difficult to reproduce this because it's pulled in by the `include_once` [here](https://github.com/civicrm/civicrm-packages/blob/a951297a605d5ba546bb22e28c3569362ec2cd03/HTML/QuickForm.php#L602) and so you only see it the first time and even clearing cache isn't enough you need to restart the web server. But the code change is straightforward.