### PR TITLE
Fixes an error uploading some images in KCFinder

### DIFF
--- a/kcfinder/lib/class_image_gd.php
+++ b/kcfinder/lib/class_image_gd.php
@@ -296,7 +296,7 @@ class image_gd extends image {
         if (!isset($args[0]))
             return false;
 
-        if (count($args[0]) == 3) {
+        if (is_array($args[0]) && count($args[0]) == 3) {
             list($r, $g, $b) = $args[0];
 
         } elseif (preg_match($exprRGB, $args[0], $match)) {


### PR DESCRIPTION
Uploading an image with KCFinder can result in a PHP fatal error.  This is triggered by uploading an image that needs resizing, where the EXIF data indicates the image is rotated.  See https://github.com/civicrm/civicrm-packages/blob/master/kcfinder/core/class/uploader.php#L649-L655

Before:
`PHP Fatal error:  Uncaught TypeError: count(): Argument #1 ($value) must be of type Countable|array, string given in .../kcfinder/lib/class_image_gd.php:299`

After:
No error.

In earlier versions of PHP, this was not fatal.